### PR TITLE
Bump nextjs13-example to 4.0.0-next.3

### DIFF
--- a/examples/nextjs-13/package.json
+++ b/examples/nextjs-13/package.json
@@ -10,6 +10,7 @@
     "lingui:extract": "lingui extract"
   },
   "dependencies": {
+    "@lingui/core": "^4.0.0-next.3",
     "@lingui/react": "^4.0.0-next.3",
     "@next/font": "13.1.2",
     "@types/node": "18.11.18",

--- a/examples/nextjs-13/package.json
+++ b/examples/nextjs-13/package.json
@@ -10,8 +10,7 @@
     "lingui:extract": "lingui extract"
   },
   "dependencies": {
-    "@lingui/core": "^4.0.0-next.2",
-    "@lingui/react": "^4.0.0-next.2",
+    "@lingui/react": "^4.0.0-next.3",
     "@next/font": "13.1.2",
     "@types/node": "18.11.18",
     "@types/react": "18.0.26",
@@ -23,9 +22,9 @@
     "typescript": "4.9.4"
   },
   "devDependencies": {
-    "@lingui/cli": "^4.0.0-next.2",
-    "@lingui/loader": "^4.0.0-next.2",
-    "@lingui/macro": "^4.0.0-next.2",
+    "@lingui/cli": "^4.0.0-next.3",
+    "@lingui/loader": "^4.0.0-next.3",
+    "@lingui/macro": "^4.0.0-next.3",
     "@lingui/swc-plugin": "^4.0.0-next.2"
   }
 }

--- a/examples/nextjs-13/src/i18n.ts
+++ b/examples/nextjs-13/src/i18n.ts
@@ -1,5 +1,4 @@
 import { i18n, Messages } from '@lingui/core';
-import { useRef, useEffect } from 'react';
 import { useRouter } from 'next/router';
 
 export const locales = [
@@ -15,21 +14,7 @@ export async function loadCatalog(locale: string) {
 export function useLinguiInit(messages: Messages) {
   const router = useRouter()
   const locale = router.locale || router.defaultLocale!
-  const firstRender = useRef(true)
-
-  // run only once on the first render (for server side)
-  if (messages && firstRender.current) {
-    i18n.load(locale, messages)
-    i18n.activate(locale)
-    firstRender.current = false
-  }
-
-  useEffect(() => {
-    if (messages) {
-      i18n.load(locale, messages)
-      i18n.activate(locale)
-    }
-  }, [locale, messages])
+  i18n.loadAndActivate(locale, messages, false);
 
   return i18n;
 }

--- a/examples/nextjs-13/yarn.lock
+++ b/examples/nextjs-13/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.1.0", "@ampproject/remapping@^2.2.0":
+"@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
   integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
@@ -21,27 +21,6 @@
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
   integrity sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==
-
-"@babel/core@7.20.12":
-  version "7.20.12"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.12.tgz#7930db57443c6714ad216953d1356dac0eb8496d"
-  integrity sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==
-  dependencies:
-    "@ampproject/remapping" "^2.1.0"
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.7"
-    "@babel/helper-compilation-targets" "^7.20.7"
-    "@babel/helper-module-transforms" "^7.20.11"
-    "@babel/helpers" "^7.20.7"
-    "@babel/parser" "^7.20.7"
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.20.12"
-    "@babel/types" "^7.20.7"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.2"
-    semver "^6.3.0"
 
 "@babel/core@^7.21.0":
   version "7.21.3"
@@ -63,15 +42,6 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.2.2"
     semver "^6.3.0"
-
-"@babel/generator@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.7.tgz#f8ef57c8242665c5929fe2e8d82ba75460187b4a"
-  integrity sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==
-  dependencies:
-    "@babel/types" "^7.20.7"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    jsesc "^2.5.1"
 
 "@babel/generator@^7.21.1", "@babel/generator@^7.21.3":
   version "7.21.3"
@@ -99,14 +69,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
-"@babel/helper-function-name@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
-  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/types" "^7.19.0"
-
 "@babel/helper-function-name@^7.21.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
@@ -128,20 +90,6 @@
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
   dependencies:
     "@babel/types" "^7.18.6"
-
-"@babel/helper-module-transforms@^7.20.11":
-  version "7.20.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz#df4c7af713c557938c50ea3ad0117a7944b2f1b0"
-  integrity sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.20.2"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.20.10"
-    "@babel/types" "^7.20.7"
 
 "@babel/helper-module-transforms@^7.21.2":
   version "7.21.2"
@@ -186,15 +134,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
-"@babel/helpers@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.7.tgz#04502ff0feecc9f20ecfaad120a18f011a8e6dce"
-  integrity sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==
-  dependencies:
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.20.7"
-    "@babel/types" "^7.20.7"
-
 "@babel/helpers@^7.21.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.21.0.tgz#9dd184fb5599862037917cdc9eecb84577dc4e7e"
@@ -237,7 +176,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@^7.18.10", "@babel/template@^7.20.7":
+"@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
   integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
@@ -245,22 +184,6 @@
     "@babel/code-frame" "^7.18.6"
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
-
-"@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.7":
-  version "7.20.12"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.12.tgz#7f0f787b3a67ca4475adef1f56cb94f6abd4a4b5"
-  integrity sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.7"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.20.7"
-    "@babel/types" "^7.20.7"
-    debug "^4.1.0"
-    globals "^11.1.0"
 
 "@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2", "@babel/traverse@^7.21.3":
   version "7.21.3"
@@ -278,7 +201,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.20.2", "@babel/types@^7.20.7":
+"@babel/types@^7.18.6", "@babel/types@^7.20.2", "@babel/types@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
@@ -474,27 +397,27 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lingui/babel-plugin-extract-messages@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-4.0.0-next.2.tgz#b83c33330b472624485d2f468320fc24b2aa5d31"
-  integrity sha512-jhOn2Cca3HDoZPb1Y2gTP6iDDvxfrsRsUDkhsrdzRaiAu8WfizEWTQnpIYg2OQME9MDt6kfRxUXYZual2yrj/A==
+"@lingui/babel-plugin-extract-messages@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-4.0.0-next.3.tgz#1667ad9e23ab93bd5f175a96441f7545686a2822"
+  integrity sha512-/NTFzEkpSW7GGsD5PPpLEOQqifbhXcU2OASbb0bnG1NhGe0KdFVMIsIO/d2RHPGXidLDdS6Q5eO/iDmcK1mrNQ==
   dependencies:
     "@babel/runtime" "^7.20.13"
 
-"@lingui/cli@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/cli/-/cli-4.0.0-next.2.tgz#edd8d92fe60862d3d2d4d3f454fc4c8b94963cc7"
-  integrity sha512-LZinon+qQB8BFCYH1kqTUza9f0Z5Lro9uZhuxYUlwt8UfIeIMeJBEZqVmsfUx6P2LKOkJ7sNfwI3E5zuF9gP8w==
+"@lingui/cli@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/cli/-/cli-4.0.0-next.3.tgz#518984d62299d5db4aa02b11f70afa3c28b66d81"
+  integrity sha512-FG8BcKOUf+UdGp9ho7kebgjbQyRe6SEydZ2CzLQVNgxgNowTqBwygnC5/13rElx1X1vJUR42Lx4OOui2r+vcbg==
   dependencies:
     "@babel/core" "^7.21.0"
     "@babel/generator" "^7.21.1"
     "@babel/parser" "^7.21.2"
     "@babel/runtime" "^7.21.0"
     "@babel/types" "^7.21.2"
-    "@lingui/babel-plugin-extract-messages" "^4.0.0-next.2"
-    "@lingui/conf" "^4.0.0-next.2"
-    "@lingui/core" "^4.0.0-next.2"
-    "@messageformat/parser" "^5.0.0"
+    "@lingui/babel-plugin-extract-messages" "^4.0.0-next.3"
+    "@lingui/conf" "^4.0.0-next.3"
+    "@lingui/core" "^4.0.0-next.3"
+    "@lingui/format-po" "^4.0.0-next.3"
     babel-plugin-macros "^3.0.1"
     chalk "^4.1.0"
     chokidar "3.5.1"
@@ -506,24 +429,19 @@
     glob "^7.1.4"
     inquirer "^7.3.3"
     micromatch "4.0.2"
-    mkdirp "^1.0.4"
-    node-gettext "^3.0.0"
     normalize-path "^3.0.0"
     ora "^5.1.0"
-    papaparse "^5.3.0"
     pkg-up "^3.1.0"
-    plurals-cldr "^1.0.4"
     pofile "^1.1.4"
     pseudolocale "^1.1.0"
     ramda "^0.27.1"
     source-map "^0.8.0-beta.0"
 
-"@lingui/conf@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/conf/-/conf-4.0.0-next.2.tgz#05c18d7d9b1a880490a38d838148f58c4769c729"
-  integrity sha512-B52Nr6oZfuuEXWhuMsyjW/HTog61dwv0fOHY06KJgbhDhZRKZ8JVuU33QsTLW8KSeGgNkbnTHTQvpNYmxygV1Q==
+"@lingui/conf@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/conf/-/conf-4.0.0-next.3.tgz#6ce046fa469f3429a2276694a99914f7eb305098"
+  integrity sha512-0Zq5vWvowAVXFiod5i6ous5gP6Q397t+/Vk+E0jXZ1EhQTSuSFC+SAR/K8h/tG1Wi3M6RdxT4zUIBWDhHongrw==
   dependencies:
-    "@babel/core" "7.20.12"
     "@babel/runtime" "^7.20.13"
     chalk "^4.1.0"
     cosmiconfig "^8.0.0"
@@ -531,40 +449,50 @@
     jiti "^1.17.1"
     lodash.get "^4.4.2"
 
-"@lingui/core@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-4.0.0-next.2.tgz#c901e3087a9ef914429dc9985f20c99d9729d5fe"
-  integrity sha512-0T841o1MscL+nroRS7WXd6+XCVCe/cvydYh/rwFDYecfXYrSDseQi5xLnPmb9lDHaFh9JKyHsr1+2HaDMYlQJQ==
+"@lingui/core@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-4.0.0-next.3.tgz#caab11b3f514109278febff7820d74d3259fea1c"
+  integrity sha512-4TYpH/JuBSNAgw1KGCx+wQgWDOXFfE3Cf0Eo4dxCvvlvydPTtbXNFZ0PGwe9B3FS7m77x2x1etm43t/35HRNiw==
   dependencies:
     "@babel/runtime" "^7.20.13"
     "@messageformat/parser" "^5.0.0"
 
-"@lingui/loader@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/loader/-/loader-4.0.0-next.2.tgz#9dc272f64b4ec2774628ae9b2d1ed0a55b880a3b"
-  integrity sha512-SeCtUtX0BuW0bBvPurayGVLJqFDVFwHgfZI4dt1MA1M1f0rGwvmymaYtEBkWdoTswdpWc3LiZK8FYnxsdecxLg==
+"@lingui/format-po@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/format-po/-/format-po-4.0.0-next.3.tgz#7ccde6fb4d2c1dbdb4354f5b243ac0b7e8858907"
+  integrity sha512-PGpuVF6Wc8c4g9WRnBki5l57UUm0ZkYaM860Fv1wtNfYL0m2GVwTjCWY3KnZHqPz3TbquOuu1/z0KHxSW7HlKQ==
+  dependencies:
+    "@lingui/cli" "^4.0.0-next.3"
+    "@lingui/conf" "^4.0.0-next.3"
+    date-fns "^2.29.3"
+    pofile "^1.1.4"
+
+"@lingui/loader@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/loader/-/loader-4.0.0-next.3.tgz#a31403a08cf88466ad1c60d92cb42abc732f63b6"
+  integrity sha512-ii07xUMYoljJ1wYt9oRwl04Jvm0li+2JTK8W7+ltkwHL3FAvCqY9h7lKCnspBMNN91SfD6kfbUddVbcjPvBI+A==
   dependencies:
     "@babel/runtime" "^7.20.13"
-    "@lingui/cli" "^4.0.0-next.2"
-    "@lingui/conf" "^4.0.0-next.2"
+    "@lingui/cli" "^4.0.0-next.3"
+    "@lingui/conf" "^4.0.0-next.3"
 
-"@lingui/macro@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/macro/-/macro-4.0.0-next.2.tgz#288863ceed3678bbddb346da31830fe23f89bc3b"
-  integrity sha512-+6dAh32MyEIbw1S5/coS0yPX1oEDC5TWszPC4Pp4Elis5hKWZQUmg7SFR/AFT0GdWw2hsgOx5vn8oDP/fs4SyA==
+"@lingui/macro@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/macro/-/macro-4.0.0-next.3.tgz#41e8b73dd3ddc06e90b03689fe686b63c60170ae"
+  integrity sha512-3AUxi/xHudJUyoHnLACQACZwFyM0mTH2YPQq52mXx4hp9BE5FrhOmmcUHoiS/BaRYdykCthHDqz3PCtyTBYULA==
   dependencies:
     "@babel/runtime" "^7.20.13"
     "@babel/types" "^7.20.7"
-    "@lingui/cli" "^4.0.0-next.2"
-    "@lingui/conf" "^4.0.0-next.2"
+    "@lingui/cli" "^4.0.0-next.3"
+    "@lingui/conf" "^4.0.0-next.3"
 
-"@lingui/react@^4.0.0-next.2":
-  version "4.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@lingui/react/-/react-4.0.0-next.2.tgz#3702386b1ba6888a99bc7d6113322390a6773272"
-  integrity sha512-2zZU2P24ztgkfwnxve6NlZGUSi/VAe0sgX7evyxNc8Y5W5mWhv6EG6o3XMChkrn9IBcT6cI7GYQkSl9/AVhrxg==
+"@lingui/react@^4.0.0-next.3":
+  version "4.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@lingui/react/-/react-4.0.0-next.3.tgz#10343bef2efc3a171906b0b8013faaa5254534cf"
+  integrity sha512-IZSmEDDWqxbMqHut3HJg66dBKSCiIVCiuADSQRfg6RI1TJUc+OCMD0god5aR7/FFMTSJ0md6KGU0Lj2/wC5n6Q==
   dependencies:
     "@babel/runtime" "^7.20.13"
-    "@lingui/core" "^4.0.0-next.2"
+    "@lingui/core" "^4.0.0-next.3"
 
 "@lingui/swc-plugin@^4.0.0-next.2":
   version "4.0.0-next.2"
@@ -1008,7 +936,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
-date-fns@^2.16.1:
+date-fns@^2.16.1, date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
@@ -1405,11 +1333,6 @@ minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 moo@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
@@ -1454,13 +1377,6 @@ next@13.1.2:
     "@next/swc-win32-arm64-msvc" "13.1.2"
     "@next/swc-win32-ia32-msvc" "13.1.2"
     "@next/swc-win32-x64-msvc" "13.1.2"
-
-node-gettext@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/node-gettext/-/node-gettext-3.0.0.tgz#6b3a253309aa1e53164646c6c644fcddd0d45c58"
-  integrity sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==
-  dependencies:
-    lodash.get "^4.4.2"
 
 node-releases@^2.0.6:
   version "2.0.8"
@@ -1525,11 +1441,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-papaparse@^5.3.0:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.2.tgz#d1abed498a0ee299f103130a6109720404fbd467"
-  integrity sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -1583,11 +1494,6 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
-
-plurals-cldr@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/plurals-cldr/-/plurals-cldr-1.0.4.tgz#534e4784f80679d3b0b39b0fb6cc46645fcf5de8"
-  integrity sha512-4nLXqtel7fsCgzi8dvRZvUjfL8SXpP982sKg7b2TgpnR8rDnes06iuQ83trQ/+XdtyMIQkBBbKzX6x97eLfsJQ==
 
 pofile@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
It looks like `@lingui/core` already comes with `@lingui/react` so removed from package.json