### PR TITLE
feat: strip non essential only for production env

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -29,7 +29,7 @@ pub struct RuntimeModulesConfigMapNormalized {
 impl LinguiJsOptions {
     pub fn to_options(self, env_name: &str) -> LinguiOptions {
         LinguiOptions {
-            strip_non_essential_fields: !(matches!(env_name, "development")),
+            strip_non_essential_fields: matches!(env_name, "production"),
             runtime_modules: RuntimeModulesConfigMapNormalized {
                 i18n: (
                     self.runtime_modules.as_ref()


### PR DESCRIPTION
in the main codebase, it seems more common we check against production instead, this also helps dev with custom env like `test` ;)