### PR TITLE
chore(compat-table): add known compatibility to v4.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ So you need to select an appropriate version of the plugin to match compatible `
 | `4.0.6`                                           | `0.87.x`        | `@swc/core@1.3.81 ~ @swc/core@1.3.105` <br /> `~ next@v14.1.0`                                                            |
 | `4.0.7`, `4.0.8`, `5.0.0-next.0` ~ `5.0.0-next.1` | `0.90.35`       | `@swc/core@1.4.0` ~ `@swc/core@1.5.0` <br /> `next@14.1.1-canary.52` ~ `v15.0.0-canary.36`  <br /> `@rspack/core@0.6.0 ~` |
 | `4.0.9`                                           | `0.96.9`        | `@swc/core@1.6.x` <br /> `next@15.0.0-canary.37 ~`                                                                        |
+| `4.0.10`                                          | `0.101.4`       | `@swc/core@1.7.15-nightly-20240820.8` ~ `@swc/core@1.7.17-nightly-20240820.3`<br /> `@rspack/core@1.0.0 ~`                |
 
 This table may become outdated. If you don't see a particular version of `@swc/core` or `next` check the compatibility by referring to the upstream's [Selecting the version](https://swc.rs/docs/plugin/selecting-swc-core) article.
 This will help you select the appropriate plugin version for your project.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ SWC Plugin support is still experimental. They do not guarantee a semver backwar
 
 So you need to select an appropriate version of the plugin to match compatible `swc_core`.
 
+It is recommended to find a suitable plugin version on https://plugins.swc.rs/.
+
+### Deprecated compatibility table
+Following table used to be updated manually and was deprecated in favour of mentioned *plugins.swc.rs.*
+
 | Plugin Version                                    | used `swc_core` | Compatibility                                                                                                             |
 |---------------------------------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------|
 | `0.1.0`, `4.0.0-next.0`                           | `0.52.8`        | `next@13.0.0` ~ `next@13.2.3`                                                                                             |


### PR DESCRIPTION
So I've checked @swc/core, rspack and next.

Apparently none stable **@swc/core** uses the swc_core@0.101.4.
Not even any canary **next** uses swc_core@0.101.4.
Rspack added.

Am I right to be rather pessimistic and write down only the versions that use exact =0.101.4? I think that's the only safe way.

Btw, I don't know how often is https://plugins.swc.rs/ updated, but maybe this table might be dropped one day in favour of the list.