### PR TITLE
fix: backslash in tagged template

### DIFF
--- a/src/ast_utils.rs
+++ b/src/ast_utils.rs
@@ -52,11 +52,19 @@ pub fn get_expr_as_string(val: &Box<Expr>) -> Option<String> {
     // `Hello`
     Expr::Tpl(Tpl {quasis, ..}) => {
       if quasis.len() == 1 {
-        return Some(quasis.get(0).unwrap().raw.to_string());
+        return Some(get_template_string_cooked_string(quasis.get(0).unwrap()));
       } else { None }
     }
 
     _ => None
+  }
+}
+
+pub fn get_template_string_cooked_string(element: &TplElement) -> String {
+  if let Some(cooked) = &element.cooked {
+    cooked.to_string()
+  } else {
+    element.raw.to_string()
   }
 }
 

--- a/src/ast_utils.rs
+++ b/src/ast_utils.rs
@@ -52,7 +52,7 @@ pub fn get_expr_as_string(val: &Box<Expr>) -> Option<String> {
     // `Hello`
     Expr::Tpl(Tpl {quasis, ..}) => {
       if quasis.len() == 1 {
-        return Some(get_template_string_cooked_string(quasis.get(0).unwrap()));
+        return Some(get_tpl_cooked_or_raw_string(quasis.get(0).unwrap()));
       } else { None }
     }
 
@@ -60,12 +60,8 @@ pub fn get_expr_as_string(val: &Box<Expr>) -> Option<String> {
   }
 }
 
-pub fn get_template_string_cooked_string(element: &TplElement) -> String {
-  if let Some(cooked) = &element.cooked {
-    cooked.to_string()
-  } else {
-    element.raw.to_string()
-  }
+pub fn get_tpl_cooked_or_raw_string(tpl: &TplElement) -> String {
+  tpl.cooked.as_ref().unwrap_or(&tpl.raw).to_string()
 }
 
 pub fn pick_jsx_attrs(mut attrs: Vec<JSXAttrOrSpread>, names: HashSet<&str>) -> Vec<JSXAttrOrSpread> {

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -110,7 +110,7 @@ impl MacroCtx {
         let mut tokens: Vec<MsgToken> = Vec::with_capacity(tpl.quasis.len());
 
         for (i, tpl_element) in tpl.quasis.iter().enumerate() {
-            tokens.push(MsgToken::String(tpl_element.raw.to_string()));
+            tokens.push(MsgToken::String(get_template_string_cooked_string(tpl_element)));
 
             if let Some(exp) = tpl.exprs.get(i) {
                 if let Expr::Call(call) = exp.as_ref() {

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -110,7 +110,7 @@ impl MacroCtx {
         let mut tokens: Vec<MsgToken> = Vec::with_capacity(tpl.quasis.len());
 
         for (i, tpl_element) in tpl.quasis.iter().enumerate() {
-            tokens.push(MsgToken::String(get_template_string_cooked_string(tpl_element)));
+            tokens.push(MsgToken::String(get_tpl_cooked_or_raw_string(tpl_element)));
 
             if let Some(exp) = tpl.exprs.get(i) {
                 if let Expr::Call(call) = exp.as_ref() {

--- a/src/tests/js_t.rs
+++ b/src/tests/js_t.rs
@@ -163,6 +163,21 @@ to!(
 );
 
 to!(
+    js_backslash_newlines_are_preserved,
+    r#"
+       import { t } from '@lingui/macro';
+         t`Multiline\nstring`;
+    "#,
+     r#"
+        import { i18n } from "@lingui/core";
+        i18n._({
+            id: "EfogM+",
+            message: "Multiline\nstring"
+        });
+     "#
+);
+
+to!(
     js_support_message_descriptor_in_t_fn,
     r#"
         import { t } from '@lingui/macro'

--- a/src/tests/jsx.rs
+++ b/src/tests/jsx.rs
@@ -309,6 +309,22 @@ to!(
     "#
 );
 
+
+// TODO: failed case
+// to!(
+//   keep_forced_newlines_in_string,
+//   r#"
+//      import { Trans } from '@lingui/macro';
+//      <Trans>{`Multiline\nstring`}</Trans>;
+//      <Trans>{"Multiline\nstring"}</Trans>;
+//   "#,
+//    r#"
+//       import { Trans } from "@lingui/react";
+//       <Trans message={"Multiline\nstring"} id={"EfogM+"}/>;
+//       <Trans message={"Multiline\nstring"} id={"EfogM+"}/>;
+//    "#
+// );
+
 to!(
     use_js_macro_in_jsx_attrs,
      r#"
@@ -404,4 +420,3 @@ to!(
 //         <Trans id="msg.hello" />;
 //       `,
 //   },
-


### PR DESCRIPTION
This PR fixes `\n` being extracted to `\\n`.