### PR TITLE
fix: lingui peerDependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "files": [],
   "peerDependencies": {
-    "@lingui/macro": "4"
+    "@lingui/core": "5"
   },
   "peerDependenciesMeta": {
     "@swc/core": {


### PR DESCRIPTION
Fixes: https://github.com/lingui/swc-plugin/issues/128

This also changes peer from `@lingui/macro` to `@lingui/core`, since v5 macro package is not required, and to express relation between core lingui code and swc plugin it's better to use `@lingui/core` as peer