### PR TITLE
fix: nested macros used in useLingui in arrow functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,11 +366,15 @@ impl<'a> Fold for LinguiMacroFolder {
             return expr;
         }
 
+        if let Expr::Arrow(arrow_expr) = expr {
+            return Expr::Arrow(self.fold_arrow_expr(arrow_expr))
+        }
+        
         let mut folder = JsMacroFolder::new(&mut self.ctx);
-
+    
         folder.fold_expr(expr).fold_children_with(self)
     }
-
+    
     fn fold_call_expr(&mut self, expr: CallExpr) -> CallExpr {
         // If no package that we care about is imported, skip the following
         // transformation logic.

--- a/src/tests/use_lingui.rs
+++ b/src/tests/use_lingui.rs
@@ -136,6 +136,39 @@ function MyComponent() {
 );
 
 to!(
+    support_nested_macro_when_in_arrow_function_issue_2095,
+    // input
+     r#"
+import { plural } from '@lingui/core/macro'
+import { useLingui } from '@lingui/react/macro'
+
+const MyComponent = () => {
+  const { t } = useLingui();
+  const a = t`Text ${plural(users.length, {
+          offset: 1,
+          0: "No books",
+          1: "1 book",
+          other: "\# books"
+        })}`;
+}
+     "#,
+    // output after transform
+    r#"
+import { useLingui as $_useLingui } from "@lingui/react";
+const MyComponent = () => {
+    const { i18n: $__i18n, _: $__ } = $_useLingui();
+    const a = $__i18n._({
+        id: "hJRCh6",
+        message: "Text {0, plural, offset:1 =0 {No books} =1 {1 book} other {# books}}",
+        values: {
+            0: users.length
+        }
+    });
+}
+    "#
+);
+
+to!(
     support_passing_t_variable_as_dependency,
     // input
      r#"


### PR DESCRIPTION
fixes: https://github.com/lingui/js-lingui/issues/2095#issuecomment-2504757207

It turned out that `ArrowFunctionExpression` falls into `Expression` category as well, unlike the regular Function, that caused nested macros such a `plural` to be processed before the outer macro is processed and get a wrong result. 