### PR TITLE
fix: linking of ident injected by useLingui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use swc_core::{
         proxies::TransformPluginProgramMetadata,
     },
 };
+use swc_core::ecma::utils::private_ident;
 
 mod ast_utils;
 mod builder;
@@ -140,7 +141,7 @@ impl LinguiMacroFolder {
                         Stmt::Decl(Decl::Var(var_decl)) => {
                             let decl = *var_decl;
 
-                            let underscore_ident = quote_ident!(SyntaxContext::empty(), "$__");
+                            let underscore_ident = private_ident!("$__");
                             let decls: Vec<VarDeclarator> = decl.decls.into_iter().map(|declarator| {
                                 if let Some(init) = &declarator.init {
                                     let expr = init.as_ref();
@@ -163,7 +164,7 @@ impl LinguiMacroFolder {
                                                                     &ident.to_id(),
                                                                 );
 
-                                                                let new_i18n_ident = quote_ident!(ident.ctxt, "$__i18n");
+                                                                let new_i18n_ident = private_ident!("$__i18n");
 
                                                                 ident_replacer = Some(IdentReplacer {
                                                                     from: ident.to_id(),
@@ -290,7 +291,7 @@ impl<'a> Fold for LinguiMacroFolder {
                 create_import(
                     i18n_source.into(),
                     quote_ident!(i18n_export[..]),
-                    self.ctx.runtime_idents.i18n.clone(),
+                    self.ctx.runtime_idents.i18n.clone().into(),
                 ),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use swc_core::common::{SyntaxContext, DUMMY_SP};
 
+use swc_core::ecma::utils::private_ident;
 use swc_core::plugin::errors::HANDLER;
 use swc_core::{
     ecma::{
@@ -13,7 +14,6 @@ use swc_core::{
         proxies::TransformPluginProgramMetadata,
     },
 };
-use swc_core::ecma::utils::private_ident;
 
 mod ast_utils;
 mod builder;

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -24,7 +24,7 @@ pub struct MacroCtx {
 
 #[derive(Clone)]
 pub struct RuntimeIdents {
-    pub i18n: IdentName,
+    pub i18n: Ident,
     pub trans: IdentName,
     pub use_lingui: IdentName,
 }
@@ -32,7 +32,7 @@ pub struct RuntimeIdents {
 impl Default for RuntimeIdents {
     fn default() -> RuntimeIdents {
         RuntimeIdents {
-            i18n: quote_ident!("$_i18n"),
+            i18n: quote_ident!("$_i18n").into(),
             trans: quote_ident!("Trans_"),
             use_lingui: quote_ident!("$_useLingui"),
         }


### PR DESCRIPTION
Fixes: https://github.com/lingui/swc-plugin/issues/150

The variable tracking in the SWC works by assigning to the `Ident` an Id. The id is generated based on scope. If `Ident` with the same name in different places has the same Id we can guarantee that it's the same variable used. 

When we inject a new variable it also has an Id, in every place we replace one `Ident` to newly created we need to ensure that id is kept. 

The root cause of the bug was when we identify a scope for `useLingui` replacement we assign a newly created `$__i18n` `Ident` to the `ctx.runtime_idents.i18n` which is in turn had a `IdentName` type, and conversion to this type effectively lost tracking information. So whenever we replace `` t`ola!` `` into `$_i18n._"ola!"` because of lack of context all following transformations (rspack for example) might rename variables inaccurately.

Writing the description above mostly for myself. I didn't find a way how to write test for this, because this requires that some 3rd party transformation should be applied. 