### PR TITLE
chore: fix all clippy warnings and improve code quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Run cargo test
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - main
       - next
     paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
+      - "README.md"
+      - "LICENSE"
 
 jobs:
   check:
@@ -18,8 +18,6 @@ jobs:
 
       # Uses values from rust-toolchain.toml
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
       # Uses values from rust-toolchain.toml
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,23 @@ cargo test js_choices_may_contain_expressions
 cargo test jsx_
 ```
 
+## Code Quality Checks
+
+Before submitting a pull request, please ensure your code passes all quality checks. The CI system will run these same checks, so running them locally will save you time.
+
+### Formatting
+```bash
+# this project uses rustfmt to enforce a consistent code style
+cargo fmt
+```
+
+### Linting
+```bash
+# we use clippy to catch common mistakes and improve code quality
+# all clippy warnings are treated as errors in the CI
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
 ## Building for production
 
 ```bash

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.85"
 targets = ["wasm32-wasip1"]
+components = ["rustfmt", "clippy"]

--- a/src/generate_id.rs
+++ b/src/generate_id.rs
@@ -8,7 +8,8 @@ pub fn generate_message_id(message: &str, context: &str) -> String {
     hasher.update(format!("{message}{UNIT_SEPARATOR}{context}"));
 
     let result = hasher.finalize();
-    return BASE64.encode(result.as_ref())[0..6].into();
+
+    BASE64.encode(result.as_ref())[0..6].into()
 }
 
 #[cfg(test)]

--- a/src/jsx_visitor.rs
+++ b/src/jsx_visitor.rs
@@ -90,7 +90,7 @@ fn is_allowed_plural_option(key: &str) -> Option<Atom> {
     None
 }
 
-impl<'a> TransJSXVisitor<'a> {
+impl TransJSXVisitor<'_> {
     // <Plural /> <Select /> <SelectOrdinal />
     fn visit_icu_macro(&mut self, el: &JSXOpeningElement, icu_format: &str) -> Vec<CaseOrOffset> {
         let mut choices: Vec<CaseOrOffset> = Vec::new();
@@ -129,7 +129,7 @@ impl<'a> TransJSXVisitor<'a> {
                                         }
                                         // some={`<Books />`}
                                         Expr::JSXElement(exp) => {
-                                            let mut visitor = TransJSXVisitor::new(&self.ctx);
+                                            let mut visitor = TransJSXVisitor::new(self.ctx);
                                             exp.visit_children_with(&mut visitor);
 
                                             tokens.extend(visitor.tokens)
@@ -157,20 +157,20 @@ impl<'a> TransJSXVisitor<'a> {
             }
         }
 
-        return choices;
+        choices
     }
 }
 
-impl<'a> Visit for TransJSXVisitor<'a> {
+impl Visit for TransJSXVisitor<'_> {
     fn visit_jsx_opening_element(&mut self, el: &JSXOpeningElement) {
         if let JSXElementName::Ident(ident) = &el.name {
-            if self.ctx.is_lingui_ident("Trans", &ident) {
+            if self.ctx.is_lingui_ident("Trans", ident) {
                 el.visit_children_with(self);
                 return;
             }
 
-            if self.ctx.is_lingui_jsx_choice_cmp(&ident) {
-                let value = match get_jsx_attr(&el, "value").and_then(|attr| attr.value.as_ref()) {
+            if self.ctx.is_lingui_jsx_choice_cmp(ident) {
+                let value = match get_jsx_attr(el, "value").and_then(|attr| attr.value.as_ref()) {
                     Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
                         expr: JSXExpr::Expr(exp),
                         ..
@@ -213,9 +213,7 @@ impl<'a> Visit for TransJSXVisitor<'a> {
 
     fn visit_jsx_text(&mut self, el: &JSXText) {
         self.tokens
-            .push(MsgToken::String(clean_jsx_element_literal_child(
-                &el.value.to_string(),
-            )));
+            .push(MsgToken::String(clean_jsx_element_literal_child(&el.value)));
     }
 
     fn visit_jsx_expr_container(&mut self, cont: &JSXExprContainer) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,11 +80,11 @@ impl LinguiMacroFolder {
 
         let context_attr_val = get_jsx_attr(&el.opening, "context")
             .and_then(|attr| attr.value.as_ref())
-            .and_then(|value| get_jsx_attr_value_as_string(value));
+            .and_then(get_jsx_attr_value_as_string);
 
-        let mut attrs = vec![create_jsx_attribute("message".into(), parsed.message)];
+        let mut attrs = vec![create_jsx_attribute("message", parsed.message)];
 
-        if !id_attr.is_some() {
+        if id_attr.is_none() {
             attrs.push(create_jsx_attribute(
                 "id",
                 generate_message_id(&parsed.message_str, &context_attr_val.unwrap_or_default())
@@ -114,7 +114,7 @@ impl LinguiMacroFolder {
 
         self.ctx.should_add_trans_import = true;
 
-        return JSXElement {
+        JSXElement {
             span: el.span,
             children: vec![],
             closing: None,
@@ -125,7 +125,7 @@ impl LinguiMacroFolder {
                 type_args: None,
                 attrs,
             },
-        };
+        }
     }
 
     pub fn handle_use_lingui(&mut self, n: BlockStmt) -> BlockStmt {
@@ -134,108 +134,125 @@ impl LinguiMacroFolder {
         let mut ident_replacer: Option<IdentReplacer> = None;
 
         let stmts: Vec<Stmt> = n
-                .stmts
-                .into_iter()
-                .map(|stmt| {
-                    return match stmt {
-                        Stmt::Decl(Decl::Var(var_decl)) => {
-                            let decl = *var_decl;
+            .stmts
+            .into_iter()
+            .map(|stmt| match stmt {
+                Stmt::Decl(Decl::Var(var_decl)) => {
+                    let decl = *var_decl;
 
-                            let underscore_ident = private_ident!("$__");
-                            let decls: Vec<VarDeclarator> = decl.decls.into_iter().map(|declarator| {
-                                if let Some(init) = &declarator.init {
-                                    let expr = init.as_ref();
+                    let underscore_ident = private_ident!("$__");
+                    let decls: Vec<VarDeclarator> = decl
+                        .decls
+                        .into_iter()
+                        .map(|declarator| {
+                            if let Some(init) = &declarator.init {
+                                let expr = init.as_ref();
 
-                                    if let Expr::Call(call) = &expr {
-                                        if match_callee_name(call, |n| {
-                                            self.ctx.is_lingui_ident("useLingui", n)
-                                        })
-                                            .is_some()
-                                        {
-                                            self.ctx.should_add_uselingui_import = true;
+                                if let Expr::Call(call) = &expr {
+                                    if match_callee_name(call, |n| {
+                                        self.ctx.is_lingui_ident("useLingui", n)
+                                    })
+                                    .is_some()
+                                    {
+                                        self.ctx.should_add_uselingui_import = true;
 
-                                            if let Pat::Object(obj_pat) = declarator.name {
-                                                let mut new_props: Vec<ObjectPatProp> =
-                                                    obj_pat.props.into_iter().map(|prop| {
-                                                        return get_local_ident_from_object_pat_prop(&prop, "t")
-                                                            .and_then(|ident| {
-                                                                ctx.register_reference(
-                                                                    &"t".into(),
-                                                                    &ident.to_id(),
-                                                                );
+                                        if let Pat::Object(obj_pat) = declarator.name {
+                                            let mut new_props: Vec<ObjectPatProp> = obj_pat
+                                                .props
+                                                .into_iter()
+                                                .map(|prop| {
+                                                    get_local_ident_from_object_pat_prop(&prop, "t")
+                                                        .map(|ident| {
+                                                            ctx.register_reference(
+                                                                &"t".into(),
+                                                                &ident.to_id(),
+                                                            );
 
-                                                                let new_i18n_ident = private_ident!("$__i18n");
+                                                            let new_i18n_ident =
+                                                                private_ident!("$__i18n");
 
-                                                                ident_replacer = Some(IdentReplacer {
-                                                                    from: ident.to_id(),
-                                                                    to: underscore_ident.clone(),
-                                                                });
+                                                            ident_replacer = Some(IdentReplacer {
+                                                                from: ident.to_id(),
+                                                                to: underscore_ident.clone(),
+                                                            });
 
-                                                                ctx.runtime_idents.i18n = new_i18n_ident.clone().into();
+                                                            ctx.runtime_idents.i18n =
+                                                                new_i18n_ident.clone();
 
-                                                                return Some(ObjectPatProp::KeyValue(
-                                                                    KeyValuePatProp {
-                                                                        value: Box::new(Pat::Ident(new_i18n_ident.into())),
-                                                                        key: PropName::Ident(quote_ident!("i18n")),
-                                                                    },
-                                                                ))
-                                                            })
-                                                            .unwrap_or(prop);
-                                                    }).collect();
+                                                            ObjectPatProp::KeyValue(
+                                                                KeyValuePatProp {
+                                                                    value: Box::new(Pat::Ident(
+                                                                        new_i18n_ident.into(),
+                                                                    )),
+                                                                    key: PropName::Ident(
+                                                                        quote_ident!("i18n"),
+                                                                    ),
+                                                                },
+                                                            )
+                                                        })
+                                                        .unwrap_or(prop)
+                                                })
+                                                .collect();
 
-                                                new_props.push(ObjectPatProp::KeyValue(
-                                                    KeyValuePatProp {
-                                                        value: Box::new(Pat::Ident(underscore_ident.clone().into())),
-                                                        key: PropName::Ident(quote_ident!("_")),
-                                                    },
-                                                ));
+                                            new_props.push(ObjectPatProp::KeyValue(
+                                                KeyValuePatProp {
+                                                    value: Box::new(Pat::Ident(
+                                                        underscore_ident.clone().into(),
+                                                    )),
+                                                    key: PropName::Ident(quote_ident!("_")),
+                                                },
+                                            ));
 
-                                                return VarDeclarator {
-                                                    init: Some(Box::new(Expr::Call(CallExpr {
-                                                        callee: Callee::Expr(Box::new(Expr::Ident(ctx.runtime_idents.use_lingui.clone().into()))),
-                                                        ..call.clone()
-                                                    }))),
+                                            return VarDeclarator {
+                                                init: Some(Box::new(Expr::Call(CallExpr {
+                                                    callee: Callee::Expr(Box::new(Expr::Ident(
+                                                        ctx.runtime_idents
+                                                            .use_lingui
+                                                            .clone()
+                                                            .into(),
+                                                    ))),
+                                                    ..call.clone()
+                                                }))),
 
-                                                    definite: true,
-                                                    span:  declarator.span,
-                                                    name: Pat::Object(ObjectPat {
-                                                        optional: false,
-                                                        type_ann: None,
-                                                        span: DUMMY_SP,
-                                                        props: new_props
-
-                                                    }),
-                                                }
-                                            } else {
-                                                HANDLER.with(|h| {
-                                                    h.struct_span_warn(decl.span, "Unsupported Syntax")
+                                                definite: true,
+                                                span: declarator.span,
+                                                name: Pat::Object(ObjectPat {
+                                                    optional: false,
+                                                    type_ann: None,
+                                                    span: DUMMY_SP,
+                                                    props: new_props,
+                                                }),
+                                            };
+                                        } else {
+                                            HANDLER.with(|h| {
+                                                h.struct_span_warn(decl.span, "Unsupported Syntax")
                                                         .note(
 r#"You have to destructure `t` when using the `useLingui` macro, i.e:
  const { t } = useLingui()
  or
  const { t: _ } = useLingui()"#)
                                                         .emit()
-                                                });
-                                            }
+                                            });
                                         }
                                     }
                                 }
+                            }
 
-                                return declarator;
-                            }).collect();
+                            declarator
+                        })
+                        .collect();
 
-                            return Stmt::Decl(Decl::Var(Box::new(VarDecl {
-                                span: decl.span,
-                                decls,
-                                declare: false,
-                                kind: decl.kind,
-                                ctxt: SyntaxContext::empty()
-                            })))
-                        }
-                        _ => stmt,
-                    };
-                })
-                .collect();
+                    Stmt::Decl(Decl::Var(Box::new(VarDecl {
+                        span: decl.span,
+                        decls,
+                        declare: false,
+                        kind: decl.kind,
+                        ctxt: SyntaxContext::empty(),
+                    })))
+                }
+                _ => stmt,
+            })
+            .collect();
 
         let mut block = BlockStmt {
             span: n.span,
@@ -251,11 +268,11 @@ r#"You have to destructure `t` when using the `useLingui` macro, i.e:
                 .fold_children_with(&mut ident_replacer.unwrap());
         }
 
-        return block.fold_children_with(self);
+        block.fold_children_with(self)
     }
 }
 
-impl<'a> Fold for LinguiMacroFolder {
+impl Fold for LinguiMacroFolder {
     fn fold_module_items(&mut self, mut n: Vec<ModuleItem>) -> Vec<ModuleItem> {
         let (i18n_source, i18n_export) = self.ctx.options.runtime_modules.i18n.clone();
         let (trans_source, trans_export) = self.ctx.options.runtime_modules.trans.clone();
@@ -400,11 +417,11 @@ impl<'a> Fold for LinguiMacroFolder {
         el = el.fold_with(&mut JsMacroFolder::new(&mut self.ctx));
 
         if let JSXElementName::Ident(ident) = &el.opening.name {
-            if self.ctx.is_lingui_ident("Trans", &ident) {
+            if self.ctx.is_lingui_ident("Trans", ident) {
                 return self.transform_jsx_macro(el, true);
             }
 
-            if self.ctx.is_lingui_jsx_choice_cmp(&ident) {
+            if self.ctx.is_lingui_jsx_choice_cmp(ident) {
                 return self.transform_jsx_macro(el, false);
             }
         }
@@ -422,7 +439,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     )
     .expect("invalid config for lingui-plugin");
 
-    let config = config.to_options(
+    let config = config.into_options(
         &metadata
             .get_context(&TransformPluginMetadataContextKind::Env)
             .unwrap_or_default(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -27,17 +27,17 @@ pub struct RuntimeModulesConfigMapNormalized {
 }
 
 impl LinguiJsOptions {
-    pub fn to_options(self, env_name: &str) -> LinguiOptions {
+    pub fn into_options(self, env_name: &str) -> LinguiOptions {
         LinguiOptions {
             strip_non_essential_fields: self
                 .strip_non_essential_fields
-                .unwrap_or_else(|| matches!(env_name, "production")),
+                .unwrap_or(matches!(env_name, "production")),
             runtime_modules: RuntimeModulesConfigMapNormalized {
                 i18n: (
                     self.runtime_modules
                         .as_ref()
                         .and_then(|o| o.i18n.as_ref())
-                        .and_then(|o| Some(o.0.clone()))
+                        .map(|o| o.0.clone())
                         .unwrap_or("@lingui/core".into()),
                     self.runtime_modules
                         .as_ref()
@@ -49,7 +49,7 @@ impl LinguiJsOptions {
                     self.runtime_modules
                         .as_ref()
                         .and_then(|o| o.trans.as_ref())
-                        .and_then(|o| Some(o.0.clone()))
+                        .map(|o| o.0.clone())
                         .unwrap_or("@lingui/react".into()),
                     self.runtime_modules
                         .as_ref()
@@ -61,7 +61,7 @@ impl LinguiJsOptions {
                     self.runtime_modules
                         .as_ref()
                         .and_then(|o| o.use_lingui.as_ref())
-                        .and_then(|o| Some(o.0.clone()))
+                        .map(|o| o.0.clone())
                         .unwrap_or("@lingui/react".into()),
                     self.runtime_modules
                         .as_ref()
@@ -166,7 +166,7 @@ mod lib_tests {
         )
         .unwrap();
 
-        let options = config.to_options("development");
+        let options = config.into_options("development");
         assert!(options.strip_non_essential_fields);
 
         let config = serde_json::from_str::<LinguiJsOptions>(
@@ -177,7 +177,7 @@ mod lib_tests {
         )
         .unwrap();
 
-        let options = config.to_options("production");
+        let options = config.into_options("production");
         assert!(!options.strip_non_essential_fields);
     }
 
@@ -190,7 +190,7 @@ mod lib_tests {
         )
         .unwrap();
 
-        let options = config.to_options("development");
+        let options = config.into_options("development");
         assert!(!options.strip_non_essential_fields);
 
         let config = serde_json::from_str::<LinguiJsOptions>(
@@ -200,7 +200,7 @@ mod lib_tests {
         )
         .unwrap();
 
-        let options = config.to_options("production");
+        let options = config.into_options("production");
         assert!(options.strip_non_essential_fields);
     }
 }


### PR DESCRIPTION
This PR addresses all clippy warnings in the codebase, making it more idiomatic Rust while maintaining all existing functionality.

## Changes made:
- **Documentation**: Updated CONTRIBUTING.md with code quality guidelines
- **CI Integration**: Added clippy checks to GitHub Actions
- **Code Quality**: Fixed all clippy warnings (70+ issues)

## Benefits:
- Enforced code quality standards in CI
- More idiomatic and readable Rust code
- Better code maintainability

## Testing:
- All tests pass: `cargo test`
- No clippy warnings: `cargo clippy --all-targets --all-features`
- No functional changes, only code style improvements
