### PR TITLE
feat: add code coverage report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,26 @@
+# https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "65...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,15 @@ on:
       - main
       - next
     paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
+      - "README.md"
+      - "LICENSE"
+  push:
+    branches:
+      - main
+      - next
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
 
 jobs:
   check:
@@ -24,5 +31,18 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
-      - name: Run cargo test
-        run: cargo test
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info
           flags: unittests
           name: codecov-umbrella

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ^target/
 target
 .idea
+lcov.info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,17 @@ It's important to build a plugin with the same Rust version used to build SWC it
 
 This project uses `rust-toolchain` file in the root of project to define rust version.
 
-To update Rust, put new version into `rust-toolchain` and call `rustup update` command
+## Code Coverage
+
+This project uses [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) to generate code coverage reports.
+
+### Installing cargo-llvm-cov
+```bash
+cargo install cargo-llvm-cov
+```
+
+### Running coverage locally
+```bash
+# Generate HTML coverage report for local viewing
+cargo llvm-cov --all-features --workspace --html --open
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Rust versions of [LinguiJS Macro](https://lingui.dev/ref/macro) [<img src="htt
 [![npm](https://img.shields.io/npm/v/@lingui/swc-plugin?logo=npm&cacheSeconds=1800)](https://www.npmjs.com/package/@lingui/swc-plugin)
 [![npm](https://img.shields.io/npm/dt/@lingui/swc-plugin?cacheSeconds=500)](https://www.npmjs.com/package/@lingui/swc-plugin)
 [![CI](https://github.com/lingui/swc-plugin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lingui/swc-plugin/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/lingui/swc-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/lingui/swc-plugin)
 [![GitHub contributors](https://img.shields.io/github/contributors/lingui/swc-plugin?cacheSeconds=1000)](https://github.com/lingui/swc-plugin/graphs/contributors)
 [![GitHub](https://img.shields.io/github/license/lingui/swc-plugin)](https://github.com/lingui/swc-plugin/blob/main/LICENSE)
 


### PR DESCRIPTION
# Add Code Coverage Report

Closes #6

This PR adds:
- CI step to run tests and generate code coverage report compatible with Codecov
- CI step to publish report to Codecov
- Coverage badge in README

@andrii-bodnar Please create `CODECOV_TOKEN` repository secret for the Codecov integration.

Note: Configuration parameters may need adjustment if necessary — I'm not entirely certain about all specific settings.
