### PR TITLE
feat: upgrade swc_core to 39.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,11 +64,10 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "3.0.0"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fb5864e2f5bf9fd9797b94b2dfd1554d4c3092b535008b27d7e15c86675a2f"
+checksum = "0a184645bcc6f52d69d8e7639720699c6a99efb711f886e251ed1d16db8dd90e"
 dependencies = [
- "proc-macro2",
  "quote",
  "swc_macros_common",
  "syn",
@@ -98,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "better_scoped_tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd297a11c709be8348aec039c8b91de16075d2b2bdaee1bd562c0875993664"
+checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
 dependencies = [
  "scoped-tls",
 ]
@@ -429,11 +428,10 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ccf961415e7aa17ef93dcb6c2441faaa8e768abe09e659b908089546f74c5"
+checksum = "308530a56b099da144ebc5d8e179f343ad928fa2b3558d1eb3db9af18d6eff43"
 dependencies = [
- "proc-macro2",
  "swc_macros_common",
  "syn",
 ]
@@ -490,14 +488,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
-version = "1.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71399f53a92ef72ee336a4b30201c6e944827e14e0af23204c291aad9c24cc85"
+checksum = "31f11d91d7befd2ffd9d216e9e5ea1fae6174b20a2a1b67a688138003d2f4122"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
- "phf",
  "rustc-hash",
  "triomphe",
 ]
@@ -875,21 +872,11 @@ checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "par-core"
-version = "1.0.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757892557993c69e82f9de0f9051e87144278aa342f03bf53617bbf044554484"
+checksum = "e96cbd21255b7fb29a5d51ef38a779b517a91abd59e2756c039583f43ef4c90f"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "par-iter"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b20f31e9ba82bfcbbb54a67aa40be6cebec9f668ba5753be138f9523c531a"
-dependencies = [
- "either",
- "par-core",
 ]
 
 [[package]]
@@ -1213,19 +1200,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.213"
+name = "seq-macro"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1332,11 +1335,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_enum"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fe66b8ee349846ce2f9557a26b8f1e74843c4a13fb381f9a3d73617a5f956a"
+checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
 dependencies = [
- "proc-macro2",
  "quote",
  "swc_macros_common",
  "syn",
@@ -1350,45 +1352,41 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swc_allocator"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b926f0d94bbb34031fe5449428cfa1268cdc0b31158d6ad9c97e0fc1e79dd"
+checksum = "9d7eefd2c8b228a8c73056482b2ae4b3a1071fbe07638e3b55ceca8570cc48bb"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.14.5",
- "ptr_meta",
  "rustc-hash",
- "triomphe",
 ]
 
 [[package]]
 name = "swc_atoms"
-version = "5.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7077ba879f95406459bc0c81f3141c529b34580bc64d7ab7bd15e7118a0391"
+checksum = "3500dcf04c84606b38464561edc5e46f5132201cb3e23cf9613ed4033d6b1bb2"
 dependencies = [
  "bytecheck",
  "hstr",
  "once_cell",
  "rancor",
  "rkyv",
- "rustc-hash",
  "serde",
 ]
 
 [[package]]
 name = "swc_common"
-version = "12.0.1"
+version = "14.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2adffdd9f42af6cfefa16b1aaa8a0984a21854637ef9d89332dd29420d4b23"
+checksum = "c2bb772b3a26b8b71d4e8c112ced5b5867be2266364b58517407a270328a2696"
 dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
  "bytecheck",
  "bytes-str",
- "cfg-if",
  "either",
  "from_variant",
  "new_debug_unreachable",
@@ -1400,7 +1398,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "siphasher",
- "swc_allocator",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_sourcemap",
@@ -1413,11 +1410,10 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "27.0.6"
+version = "39.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b047b6c583f238704fda957aa88d379100216c742a79d4d8f90ef85f0bf5ea38"
+checksum = "56ad087b00477b9d310b5ebfa26acb867be338765558632597976ee56c898b63"
 dependencies = [
- "once_cell",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
@@ -1436,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "12.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82007a7a4fb30198baf82f79244aca929d9845e16fcf897179773e4ebfed20f5"
+checksum = "65c25af97d53cf8aab66a6c68f3418663313fc969ad267fc2a4d19402c329be1"
 dependencies = [
  "bitflags",
  "bytecheck",
@@ -1449,7 +1445,6 @@ dependencies = [
  "rancor",
  "rkyv",
  "rustc-hash",
- "scoped-tls",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -1459,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "14.0.0"
+version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af054998dc8a578e8232b94ef046fe06f470b6d8f7f3cbe5c37e7f71dd0e48db"
+checksum = "bcf55c2d7555c93f4945e29f93b7529562be97ba16e60dd94c25724d746174ac"
 dependencies = [
  "ascii",
  "compact_str",
@@ -1483,30 +1478,28 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99e1931669a67c83e2c2b4375674f6901d1480994a76aa75b23f1389e6c5076"
+checksum = "e276dc62c0a2625a560397827989c82a93fd545fcf6f7faec0935a82cc4ddbb8"
 dependencies = [
  "proc-macro2",
- "quote",
  "swc_macros_common",
  "syn",
 ]
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "15.0.2"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e1f330dc2c4b381232b00f32b5de2c7178e2cdb5249f4c41ec9e13d45c66a5"
+checksum = "017d06ea85008234aa9fb34d805c7dc563f2ea6e03869ed5ac5a2dc27d561e4d"
 dependencies = [
  "arrayvec",
  "bitflags",
  "either",
- "new_debug_unreachable",
  "num-bigint",
- "num-traits",
  "phf",
  "rustc-hash",
+ "seq-macro",
  "serde",
  "smallvec",
  "smartstring",
@@ -1515,40 +1508,29 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_parser"
-version = "15.0.2"
+version = "24.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f78a70fc7b448889412e42a730f1e34f2850b1fd49af424e39248135ada747b"
+checksum = "2e9011783c975ba592ffc09cd208ced92b1dfabb2e5e0ef453559e2e25286127"
 dependencies = [
- "arrayvec",
- "bitflags",
  "either",
- "new_debug_unreachable",
  "num-bigint",
- "num-traits",
- "phf",
- "rustc-hash",
  "serde",
- "smallvec",
- "smartstring",
- "stacker",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_lexer",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07366b063e9ae158868ff28a867ff6e295dc373bc2eb3b704070041baf968f0a"
+checksum = "bd297865d417cf7e99bf36f4f29928e89ccf3446b56440e110b2f488f6d8d2d0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1559,19 +1541,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "16.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c511aff4fabb634c1799a6d6fa2a5057a4f0f482e097e31aeb43939b0ad601"
+checksum = "a0526b4e3d6cedb7e48c5026242809387676f836d4251235fa95165218bb8ce4"
 dependencies = [
  "better_scoped_tls",
- "bitflags",
  "indexmap",
  "once_cell",
  "par-core",
  "phf",
  "rustc-hash",
  "serde",
- "smallvec",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1583,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "19.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f31fd1f0f220445f432038fc9592c8df3bb5e9e63f921e38de1077dc942e1"
+checksum = "b394293ee1a70c986aac9282d606cfb05d0ee81f7f48958e3975e33886bd8745"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1594,7 +1574,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "swc_allocator",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -1610,15 +1589,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "16.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8afc858d9cd7aa2b480d55174ff9c7ee02de003ac5f9e140398206af566b0f"
+checksum = "83259addd99ed4022aa9fc4d39428c008d3d42533769e1a005529da18cde4568"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
- "par-iter",
  "rustc-hash",
  "ryu-js",
  "swc_atoms",
@@ -1626,14 +1604,13 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
- "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "12.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0698960f28169c5eaa01127273aca31999bbbb6b1d3f2576ee5400daaa295d0a"
+checksum = "75a579aa8f9e212af521588df720ccead079c09fe5c8f61007cf724324aed3a0"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -1646,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "swc_eq_ignore_macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96e15288bf385ab85eb83cff7f9e2d834348da58d0a31b33bdb572e66ee413e"
+checksum = "c16ce73424a6316e95e09065ba6a207eba7765496fed113702278b7711d4b632"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1657,25 +1634,22 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "14.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863dea960d5c8646125462d5b283b03a8b709879729c6713c14e413b0c7a3f8f"
+checksum = "b7a16e3c08fd820735631820a7c220d5ce39bdc08b83eddbc73a645ef744511e"
 dependencies = [
  "anyhow",
  "miette",
  "once_cell",
- "parking_lot",
  "serde",
- "serde_derive",
- "serde_json",
  "swc_common",
 ]
 
 [[package]]
 name = "swc_macros_common"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a509f56fca05b39ba6c15f3e58636c3924c78347d63853632ed2ffcb6f5a0ac7"
+checksum = "aae1efbaa74943dc5ad2a2fb16cbd78b77d7e4d63188f3c5b4df2b4dcd2faaae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1684,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b45099a38ed45528bef939d0eac1a0c1347749d0c67d3dd744d545316c5fd05"
+checksum = "92b27449420554de6ad8d49004ad3d36e6ac64ecb51d1b0fe1002afcd7a45d85"
 dependencies = [
  "once_cell",
 ]
@@ -1704,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "12.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55c2e46b9cc32e206a6f041621468717bbc5748d3321f2e99648340843d16ce"
+checksum = "79e78029030baf942203f11eae0ea47c07367d167060ba4c55a202a1341366c5"
 dependencies = [
  "better_scoped_tls",
  "bytecheck",
@@ -1750,23 +1724,21 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d2564e80c5c664914f327640288f5637b0f0acf6a340b92e0082655e558f51"
+checksum = "ca33f282df60eefee05511c9aaf557696d2f9f0e22f4a5abca318da10c22f1cc"
 dependencies = [
  "better_scoped_tls",
- "once_cell",
  "rustc-hash",
  "serde",
- "serde_json",
  "swc_common",
 ]
 
 [[package]]
 name = "swc_visit"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9138b6a36bbe76dd6753c4c0794f7e26480ea757bee499738bedbbb3ae3ec5f3"
+checksum = "62fb71484b486c185e34d2172f0eabe7f4722742aad700f426a494bb2de232a2"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -1824,11 +1796,10 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6995a7c9eaf999e15d3c367e6d8443323c35965a424beb224cdb98dd6a35af83"
+checksum = "cb14720ff995a98916e7fafc6771242727ed1ac5f2725059f03f203586d8ca1b"
 dependencies = [
- "ansi_term",
  "cargo_metadata",
  "difference",
  "once_cell",
@@ -1846,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "testing_macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d27bf245b90a80d5aa231133418ae7db98f032855ce5292e12071ab29c4b26"
+checksum = "b7442bd3ca09f38d4788dc5ebafbc1967c3717726b4b074db011d470b353548b"
 dependencies = [
  "anyhow",
  "glob",
@@ -1998,22 +1969,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicode-id"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
 
 [[package]]
 name = "unicode-id-start"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.207"
 serde_json = "1.0.125"
 regex = "1.10.6"
 once_cell = "1.19.0"
-swc_core = { version = "27.0.6", features = [
+swc_core = { version = "39.0.3", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Below is a table referencing the swc_core version used during the plugin build, 
 | `5.4.0`                                           | [`14.1.0`](https://plugins.swc.rs/versions/range/138) |
 | `5.5.0` ~ `5.5.2`                                 | [`15.0.1`](https://plugins.swc.rs/versions/range/271) |
 | `5.6.0` ~ `5.6.1`                                 | [`27.0.6`](https://plugins.swc.rs/versions/range/364) |
+| `5.7.0`                                           | [`39.0.3`](https://plugins.swc.rs/versions/range/426) |
 
 
 > **Note**


### PR DESCRIPTION
Upgrading swc_core to 39.0.3 to make the package with the next compat range `@33.0.0 - < 40.0.0` (https://plugins.swc.rs/versions/range/426)

In this way, the package will be compatible with Next.js 15.5

Related to this https://github.com/lingui/swc-plugin/pull/170#issuecomment-3620612882

### Testing

```
$ cargo test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running unittests src/lib.rs (target/debug/deps/lingui_macro_plugin-5a34ca36389b2e54)

running 102 tests
test options::lib_tests::test_config_optional ... ok
test options::lib_tests::test_strip_non_essential_fields_default ... ok
test options::lib_tests::test_strip_non_essential_fields_config ... ok
test options::lib_tests::test_config ... ok
test generate_id::tests::test_generate_message_id_with_context ... ok
test generate_id::tests::test_generate_message_id ... ok
test tests::imports::should_add_imports_after_directive_prologues ... ok
test tests::js_define_message::should_expand_macros ... ok
test tests::js_define_message::should_expand_values ... ok
test tests::js_define_message::should_kept_only_essential_props ... ok
test tests::js_define_message::define_message_should_support_template_literal ... ok
test tests::imports::js_should_process_only_elements_imported_from_macro2 ... ok
test tests::imports::js_should_support_renamed_imports ... ok
test tests::imports::js_should_process_only_elements_imported_from_macro ... ok
test tests::js_define_message::should_preserve_custom_id ... ok
test tests::js_define_message::should_transform_define_message ... ok
test tests::js_icu::js_dedup_values_in_icu ... ok
test tests::js_icu::js_icu_nested_in_choices ... ok
test tests::js_icu::js_choices_may_contain_expressions ... ok
test tests::js_icu::js_icu_diffrent_object_literal_syntax ... ok
test tests::js_icu::js_icu_nested_in_t ... ok
test tests::js_icu::js_icu_macro ... ok
test tests::js_icu::js_plural_with_offset_and_exact_matches ... ok
test tests::js_icu::js_should_not_touch_non_lungui_fns ... ok
test tests::js_icu::js_plural_with_placeholders ... ok
test tests::js_icu::js_should_not_treat_offset_in_select ... ok
test tests::js_t::js_continuation_character ... ok
test tests::js_t::js_dedup_values_in_tpl_literal ... ok
test tests::js_t::js_choice_labels_in_tpl_literal ... ok
test tests::js_t::js_should_not_touch_code_if_no_macro_import ... ok
test tests::js_t::js_newlines_are_preserved ... ok
test tests::js_t::js_custom_i18n_passed ... ok
test tests::js_t::js_should_kept_only_essential_props ... ok
test tests::js_t::js_should_not_touch_not_related_tagget_tpls ... ok
test tests::js_t::js_explicit_labels_in_tpl_literal ... ok
test tests::js_t::js_should_work_with_legacy_import ... ok
test tests::js_t::js_ph_labels_in_tpl_literal ... ok
test tests::js_t::js_support_message_descriptor_in_t_fn ... ok
test tests::js_t::js_support_template_strings_in_t_macro_message_with_custom_i18n_instance ... ok
test tests::js_t::js_substitution_in_tpl_literal ... ok
test tests::js_t::js_t_fn_wrapped_in_call_expr ... ok
test tests::js_t::support_id_and_comment_in_t_macro_as_call_expression ... ok
test tests::js_t::should_generate_diffrent_id_when_context_provided ... ok
test tests::js_t::support_id_in_template_literal ... ok
test tests::js_t::unicode_characters_interpreted ... ok
test tests::jsx::elements_without_children ... ok
test tests::jsx::elements_inside_expression_container ... ok
test tests::jsx::ignore_jsx_empty_expression ... ok
test tests::jsx::jsx_explicit_labels_with_as_statement ... ok
test tests::jsx::html_attributes_are_handled ... ok
test tests::jsx::jsx_preserve_reserved_attrs ... ok
test tests::jsx::jsx_nested_labels ... ok
test tests::jsx::jsx_should_suppor_legacy_import ... ok
test tests::jsx::jsx_template_literal_in_children ... ok
test tests::jsx::jsx_simple_jsx ... ok
test tests::jsx::jsx_with_custom_id ... ok
test tests::jsx::jsx_components_interpolation ... ok
test tests::imports::jsx_should_process_only_elements_imported_from_macro2 ... ok
test tests::imports::jsx_should_process_only_elements_imported_from_macro ... ok
test tests::imports::should_add_not_clashing_imports ... ok
test tests::jsx::jsx_with_context ... ok
test tests::imports::jsx_should_support_renamed_imports ... ok
test tests::jsx::jsx_expressions_are_converted_to_positional_arguments ... ok
test tests::jsx::jsx_values_dedup ... ok
test tests::jsx::production_only_essential_props_are_kept ... ok
test tests::jsx::keep_multiple_forced_newlines ... ok
test tests::jsx::use_js_plural_in_jsx_attrs ... ok
test tests::jsx::use_decoded_html_entities ... ok
test tests::jsx::quoted_jsx_attributes_are_handled ... ok
test tests::jsx::strip_whitespace_around_arguments ... ok
test tests::jsx_icu::jsx_icu ... ok
test tests::jsx_icu::jsx_icu_explicit_id ... ok
test tests::jsx::normalize_crlf_lf_cr ... ok
test tests::jsx_icu::jsx_icu_with_template_literal ... ok
test tests::jsx_icu::jsx_plural_preserve_reserved_attrs ... ok
test tests::jsx::use_js_macro_in_jsx_attrs ... ok
test tests::jsx::strip_whitespace_around_tags_but_keep_forced_spaces ... ok
test tests::jsx_icu::jsx_select_ordinal_with_offset_and_exact_matches ... ok
test tests::jsx_icu::jsx_plural_with_offset_and_exact_matches ... ok
test tests::jsx::non_breaking_whitespace_handling_2226 ... ok
test tests::jsx::jsx_explicit_labels ... ok
test tests::use_lingui::js_use_lingui_hook ... ok
test tests::jsx_icu::jsx_icu_nested ... ok
test tests::jsx::jsx_ph_labels ... ok
test tests::jsx_icu::production_only_essential_props_are_kept ... ok
test tests::runtime_config::should_use_provided_runtime_modules ... ok
test tests::use_lingui::support_nested_macro ... ok
test tests::jsx_icu::jsx_select_simple ... ok
test tests::use_lingui::should_process_macro_with_matching_name_in_correct_scopes ... ok
test tests::jsx_icu::jsx_select_with_expressions_in_cases ... ok
test tests::jsx_icu::jsx_select_with_reserved_attrs ... ok
test tests::use_lingui::support_nested_macro_when_in_arrow_function_issue_2095 ... ok
test tests::use_lingui::support_renamed_destructuring ... ok
test tests::use_lingui::work_when_t_is_not_used ... ok
test tests::use_lingui::support_passing_t_variable_as_dependency ... ok
test tests::use_lingui::work_with_components_defined_as_arrow_function ... ok
test tests::use_lingui::work_with_existing_use_lingui_statement ... ok
test tests::jsx_icu::multiple_new_lines_with_nbsp_endind ... ok
test tests::use_lingui::work_with_multiple_react_components ... ok
test tests::jsx::strip_whitespaces_in_jsxtext_but_keep_in_jsx_expression_containers ... ok
test tests::jsx_icu::jsx_trans_inside_plural ... ok
test tests::jsx_icu::jsx_multivelel_nesting ... ok

test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

```

Tested with the example updating it to  Nextjs 15.5

```
npm run build:local-binary

> my-app@0.1.0 build:local-binary
> USE_LOCAL_PLUGIN_BINARY=true next build

   ▲ [Next.js](http://next.js/) 15.5.7
   - Experiments (use with caution):
     · swcPlugins

 ✓ Linting and checking validity of types    
   Creating an optimized production build ...
 ✓ Compiled successfully in 5.0s
 ✓ Collecting page data    
 ✓ Generating static pages (6/6)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (pages)                                Size  First Load JS    
┌ ƒ /                                       724 B        87.9 kB
├   /_app                                     0 B        87.2 kB
└ ○ /404                                    180 B        87.3 kB
+ First Load JS shared by all             88.1 kB
  ├ chunks/[framework-37f3832b4337c515.js](http://framework-37f3832b4337c515.js/)  44.8 kB
  ├ chunks/[main-729f40dfc08aa5c9.js](http://main-729f40dfc08aa5c9.js/)       36.7 kB
  └ other shared chunks (total)           6.54 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

```