### PR TITLE
fix: build with `--cfg=swc_ast_unknown`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,8 @@
 # Alias to build actual plugin binary for the specified target.
 build-wasi = "build --target wasm32-wasip1"
 build-wasm32 = "build --target wasm32-unknown-unknown"
+
+[target.'cfg(target_arch = "wasm32")']
+rustflags = [
+  "--cfg=swc_ast_unknown"
+]

--- a/README.md
+++ b/README.md
@@ -89,32 +89,37 @@ SWC Plugin support is still experimental. They do not guarantee a semver backwar
 
 So you need to select an appropriate version of the plugin to match compatible `swc_core` using a https://plugins.swc.rs/.
 
-Below is a table referencing the swc_core version used during the plugin build, along with a link to the plugin's site to check compatibility with runtimes for this swc_core range.
+Below is a table referencing the `swc_core` version used during the plugin build, along with a link to the plugin's site to check compatibility with runtimes for this `swc_core` range.
 
-| Plugin Version                                    | used `swc_core`                                       |
-|---------------------------------------------------|-------------------------------------------------------|
-| `0.1.0`, `4.0.0-next.0`                           | `0.52.8`                                              |
-| `0.2.*`, `4.0.0-next.1` ~ `4.0.0-next.3`          | `0.56.1`                                              |
-| `4.0.0`                                           | `0.75.33`                                             |
-| `4.0.1`                                           | `0.76.0`                                              |
-| `4.0.2`                                           | `0.76.41`                                             |
-| `4.0.3`                                           | `0.78.28`                                             |
-| `4.0.4`                                           | `0.79.x`                                              |
-| `4.0.5`, `4.0.6`                                  | [`0.87.x`](https://plugins.swc.rs/versions/range/10)  |
-| `4.0.7`, `4.0.8`, `5.0.0-next.0` ~ `5.0.0-next.1` | [`0.90.35`](https://plugins.swc.rs/versions/range/12) |
-| `4.0.9`                                           | [`0.96.9`](https://plugins.swc.rs/versions/range/15)  |
-| `4.0.10`                                          | [`0.101.4`](https://plugins.swc.rs/versions/range/94) |
-| `4.1.0`, `5.0.0` ~ `5.2.0`                        | [`0.106.3`](https://plugins.swc.rs/versions/range/95) |
-| `5.3.0`                                           | [`5.0.4`](https://plugins.swc.rs/versions/range/116)  |
-| `5.4.0`                                           | [`14.1.0`](https://plugins.swc.rs/versions/range/138) |
-| `5.5.0` ~ `5.5.2`                                 | [`15.0.1`](https://plugins.swc.rs/versions/range/271) |
-| `5.6.0` ~ `5.6.1`                                 | [`27.0.6`](https://plugins.swc.rs/versions/range/364) |
-| `5.7.0`                                           | [`39.0.3`](https://plugins.swc.rs/versions/range/426) |
-| `5.8.0`                                           | [`45.0.2`](https://plugins.swc.rs/versions/range/497) |
-| `5.9.0`                                           | [`46.0.3`](https://plugins.swc.rs/versions/range/713) |
-| `5.10.0`                                          | [`50.2.3`](https://plugins.swc.rs/versions/range/768) |
+To learn more about SWC Plugins compatibility check this issue https://github.com/lingui/swc-plugin/issues/179
+
+| Plugin Version                                    | used `swc_core`                                                                                                                                                       |
+|---------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `0.1.0`, `4.0.0-next.0`                           | `0.52.8`                                                                                                                                                              |
+| `0.2.*`, `4.0.0-next.1` ~ `4.0.0-next.3`          | `0.56.1`                                                                                                                                                              |
+| `4.0.0`                                           | `0.75.33`                                                                                                                                                             |
+| `4.0.1`                                           | `0.76.0`                                                                                                                                                              |
+| `4.0.2`                                           | `0.76.41`                                                                                                                                                             |
+| `4.0.3`                                           | `0.78.28`                                                                                                                                                             |
+| `4.0.4`                                           | `0.79.x`                                                                                                                                                              |
+| `4.0.5`, `4.0.6`                                  | [`0.87.x`](https://plugins.swc.rs/versions/range/10)                                                                                                                  |
+| `4.0.7`, `4.0.8`, `5.0.0-next.0` ~ `5.0.0-next.1` | [`0.90.35`](https://plugins.swc.rs/versions/range/12)                                                                                                                 |
+| `4.0.9`                                           | [`0.96.9`](https://plugins.swc.rs/versions/range/15)                                                                                                                  |
+| `4.0.10`                                          | [`0.101.4`](https://plugins.swc.rs/versions/range/94)                                                                                                                 |
+| `4.1.0`, `5.0.0` ~ `5.2.0`                        | [`0.106.3`](https://plugins.swc.rs/versions/range/95)                                                                                                                 |
+| `5.3.0`                                           | [`5.0.4`](https://plugins.swc.rs/versions/range/116)                                                                                                                  |
+| `5.4.0`                                           | [`14.1.0`](https://plugins.swc.rs/versions/range/138)                                                                                                                 |
+| `5.5.0` ~ `5.5.2`                                 | [`15.0.1`](https://plugins.swc.rs/versions/range/271)                                                                                                                 |
+| `5.6.0` ~ `5.6.1`                                 | [`27.0.6`](https://plugins.swc.rs/versions/range/364)                                                                                                                 |
+| `5.7.0`                                           | [`39.0.3`](https://plugins.swc.rs/versions/range/426)                                                                                                                 |
+| `5.8.0`                                           | [`45.0.2`](https://plugins.swc.rs/versions/range/497)                                                                                                                 |
+| `5.9.0`                                           | [`46.0.3`](https://plugins.swc.rs/versions/range/713)                                                                                                                 |
+| `5.10.0`                                          | [`50.2.3`](https://plugins.swc.rs/versions/range/768)                                                                                                                 |
+| `5.10.1`                                          | [`50.2.3`](https://plugins.swc.rs/versions/range/768) with [`--cfg=swc_ast_unknown`](https://swc.rs/docs/plugin/ecmascript/compatibility#make-your-plugin-compatible) |
+
 
 > **Note**
+>
 > next `v13.2.4` ~ `v13.3.1` cannot execute SWC Wasm plugins, due to a [bug of next-swc](https://github.com/vercel/next.js/issues/46989#issuecomment-1486989081).
 >
 > next `v13.4.3` ~ `v13.4.5-canary.7` cannot execute SWC Wasm plugins, due to [missing filesystem cache](https://github.com/vercel/next.js/pull/50651).


### PR DESCRIPTION
https://swc.rs/docs/plugin/ecmascript/compatibility#make-your-plugin-compatible

Enable backward compatibility for plugins 