### PR TITLE
feat: support corePackage/jsxPackage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ When using SWC directly via CLI or a JSON-only configuration, pass options manua
 
 ## Options
 
+### `corePackage`
+
+Defines which module specifiers the plugin should treat as core macro imports.
+
+Defaults to `[@lingui/macro, @lingui/core/macro]` for backwards compatibility with the legacy combined macro entrypoint.
+
+### `jsxPackage`
+
+Defines which module specifiers the plugin should treat as JSX macro imports.
+
+Defaults to `[@lingui/macro, @lingui/react/macro]` for backwards compatibility with the legacy combined macro entrypoint.
+
 ### `descriptorFields`
 
 Controls which fields are preserved in the transformed message descriptors. Accepts one of:

--- a/e2e/fixtures/lingui-options/custom.config.js
+++ b/e2e/fixtures/lingui-options/custom.config.js
@@ -7,6 +7,8 @@ export default {
     useLingui: ["@custom/react", "useCustomLingui"],
   },
   macro: {
+    corePackage: ["@custom/core/macro"],
+    jsxPackage: ["@custom/react/macro"],
     jsxPlaceholderAttribute: "data-i18n",
     jsxPlaceholderDefaults: {
       a: "anchor",

--- a/e2e/options.test.ts
+++ b/e2e/options.test.ts
@@ -16,6 +16,12 @@ describe("linguiMacroSwcPlugin", () => {
         [
           "@lingui/swc-plugin",
           {
+            "corePackage": [
+              "@lingui/core/macro",
+            ],
+            "jsxPackage": [
+              "@lingui/react/macro",
+            ],
             "jsxPlaceholderAttribute": "_t",
             "jsxPlaceholderDefaults": {
               "a": "link",
@@ -49,6 +55,12 @@ describe("linguiMacroSwcPlugin", () => {
       [
         "@lingui/swc-plugin",
         {
+          "corePackage": [
+            "@custom/core/macro",
+          ],
+          "jsxPackage": [
+            "@custom/react/macro",
+          ],
           "jsxPlaceholderAttribute": "data-i18n",
           "jsxPlaceholderDefaults": {
             "a": "anchor",
@@ -77,6 +89,8 @@ describe("linguiMacroSwcPlugin", () => {
     expect(
       linguiMacroSwcPlugin(
         {
+          corePackage: ["@override/core/macro"],
+          jsxPackage: ["@override/react/macro"],
           jsxPlaceholderAttribute: "data-test",
           runtimeModules: {
             trans: ["@override/react", "OverrideTrans"],
@@ -88,6 +102,12 @@ describe("linguiMacroSwcPlugin", () => {
       [
         "@lingui/swc-plugin",
         {
+          "corePackage": [
+            "@override/core/macro",
+          ],
+          "jsxPackage": [
+            "@override/react/macro",
+          ],
           "jsxPlaceholderAttribute": "data-test",
           "jsxPlaceholderDefaults": {
             "a": "anchor",

--- a/src-js/options.ts
+++ b/src-js/options.ts
@@ -4,6 +4,10 @@ export type RuntimeModuleConfig = readonly [modulePath: string, exportName?: str
 
 /** Options accepted by the `@lingui/swc-plugin` WASM plugin. */
 export type LinguiMacroOptions = {
+  /** Module specifiers treated as core macro imports, such as `t`, `msg`, and `defineMessage`. */
+  corePackage?: string[]
+  /** Module specifiers treated as JSX macro imports, such as `Trans` and `useLingui`. */
+  jsxPackage?: string[]
   /** JSX attribute name used to provide explicit placeholder names inside `<Trans>` content. */
   jsxPlaceholderAttribute?: string
   /** Default placeholder names for JSX tags when no explicit placeholder attribute is present. */
@@ -77,6 +81,8 @@ export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>
   const {i18n, Trans, useLingui} = config.runtimeConfigModule
 
   const macroOptions: LinguiMacroOptions = {
+    corePackage: config.macro.corePackage,
+    jsxPackage: config.macro.jsxPackage,
     jsxPlaceholderAttribute: config.macro.jsxPlaceholderAttribute,
     jsxPlaceholderDefaults: config.macro.jsxPlaceholderDefaults,
     ...overrides,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@ impl<C> LinguiMacroFolder<C>
 where
     C: Comments + Clone,
 {
-    pub fn new(options: LinguiOptions, comments: Option<C>) -> LinguiMacroFolder<C> {
+    pub fn new(mut options: LinguiOptions, comments: Option<C>) -> LinguiMacroFolder<C> {
+        options.sync_derived_fields();
+
         LinguiMacroFolder {
             has_lingui_macro_imports: false,
             ctx: MacroCtx::new(options),
@@ -382,11 +384,14 @@ where
 
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
-                // drop macro imports
-                if &imp.src.value == "@lingui/macro"
-                    || &imp.src.value == "@lingui/core/macro"
-                    || &imp.src.value == "@lingui/react/macro"
-                {
+                let is_macro_import = self
+                    .ctx
+                    .options
+                    .all_macro_packages
+                    .iter()
+                    .any(|package| imp.src.value == package.as_str());
+
+                if is_macro_import {
                     self.has_lingui_macro_imports = true;
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
@@ -535,7 +540,10 @@ where
     }
 }
 
-pub use self::options::{DescriptorFields, LinguiOptions, RuntimeModulesConfigMapNormalized};
+pub use self::options::{
+    DescriptorFields, LinguiOptions, MacroPackagesConfigNormalized,
+    RuntimeModulesConfigMapNormalized,
+};
 
 #[plugin_transform]
 pub fn process_transform(program: Program, metadata: TransformPluginProgramMetadata) -> Program {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,7 @@ impl<C> LinguiMacroFolder<C>
 where
     C: Comments + Clone,
 {
-    pub fn new(mut options: LinguiOptions, comments: Option<C>) -> LinguiMacroFolder<C> {
-        options.sync_derived_fields();
-
+    pub fn new(options: LinguiOptions, comments: Option<C>) -> LinguiMacroFolder<C> {
         LinguiMacroFolder {
             has_lingui_macro_imports: false,
             ctx: MacroCtx::new(options),
@@ -386,7 +384,6 @@ where
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
                 let is_macro_import = self
                     .ctx
-                    .options
                     .all_macro_packages
                     .iter()
                     .any(|package| imp.src.value == package.as_str());

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -32,6 +32,8 @@ pub struct MacroCtx {
     // local name -> export name
     id_to_symbol_map: HashMap<Id, Atom>,
 
+    pub all_macro_packages: Vec<String>,
+
     pub should_add_18n_import: bool,
     pub should_add_trans_import: bool,
     pub should_add_uselingui_import: bool,
@@ -60,7 +62,10 @@ impl Default for RuntimeIdents {
 
 impl MacroCtx {
     pub fn new(options: LinguiOptions) -> MacroCtx {
+        let all_macro_packages = options.macro_packages.all_macro_packages();
+
         MacroCtx {
+            all_macro_packages,
             options,
             ..Default::default()
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -111,12 +111,6 @@ impl Default for RuntimeModulesConfigMapNormalized {
     }
 }
 
-impl LinguiOptions {
-    pub fn sync_derived_fields(&mut self) {
-        self.all_macro_packages = self.macro_packages.all_macro_packages();
-    }
-}
-
 impl LinguiJsOptions {
     pub fn into_options(self, env_name: &str) -> LinguiOptions {
         let descriptor_fields = match self.descriptor_fields.unwrap_or(DescriptorFields::Auto) {
@@ -138,7 +132,6 @@ impl LinguiJsOptions {
                 .jsx_package
                 .unwrap_or_else(|| MacroPackagesConfigNormalized::default().jsx),
         };
-        let all_macro_packages = macro_packages.all_macro_packages();
 
         LinguiOptions {
             descriptor_fields,
@@ -147,7 +140,6 @@ impl LinguiJsOptions {
             jsx_placeholder_attribute: self.jsx_placeholder_attribute.clone(),
             jsx_placeholder_defaults: self.jsx_placeholder_defaults.clone(),
             macro_packages,
-            all_macro_packages,
             runtime_modules: RuntimeModulesConfigMapNormalized {
                 i18n: (
                     self.runtime_modules
@@ -202,8 +194,6 @@ pub struct LinguiOptions {
     pub jsx_placeholder_defaults: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "is_default")]
     pub macro_packages: MacroPackagesConfigNormalized,
-    #[serde(skip)]
-    pub all_macro_packages: Vec<String>,
     #[serde(skip_serializing_if = "is_default")]
     pub runtime_modules: RuntimeModulesConfigMapNormalized,
     #[serde(skip_serializing_if = "is_default")]
@@ -212,16 +202,13 @@ pub struct LinguiOptions {
 
 impl Default for LinguiOptions {
     fn default() -> LinguiOptions {
-        let macro_packages = MacroPackagesConfigNormalized::default();
-
         LinguiOptions {
             descriptor_fields: DescriptorFields::All,
             use_lingui_v5_id_generation: false,
             id_prefix_leader: None,
             jsx_placeholder_attribute: None,
             jsx_placeholder_defaults: None,
-            all_macro_packages: macro_packages.all_macro_packages(),
-            macro_packages,
+            macro_packages: Default::default(),
             runtime_modules: Default::default(),
         }
     }
@@ -320,7 +307,7 @@ mod lib_tests {
             }
         );
         assert_eq!(
-            options.all_macro_packages,
+            options.macro_packages.all_macro_packages(),
             vec!["@lingui/macro", "@lingui/core/macro", "@lingui/react/macro"]
         );
     }
@@ -345,7 +332,7 @@ mod lib_tests {
             }
         );
         assert_eq!(
-            options.all_macro_packages,
+            options.macro_packages.all_macro_packages(),
             vec!["@acme/core/macro", "@acme/react/macro"]
         );
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -34,6 +34,10 @@ impl DescriptorFields {
 pub struct LinguiJsOptions {
     runtime_modules: Option<RuntimeModulesConfigMap>,
     #[serde(default)]
+    core_package: Option<Vec<String>>,
+    #[serde(default)]
+    jsx_package: Option<Vec<String>>,
+    #[serde(default)]
     descriptor_fields: Option<DescriptorFields>,
     #[serde(default)]
     use_lingui_v5_id_generation: Option<bool>,
@@ -63,6 +67,40 @@ pub struct RuntimeModulesConfigMapNormalized {
     pub use_lingui: (String, String),
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MacroPackagesConfigNormalized {
+    pub core: Vec<String>,
+    pub jsx: Vec<String>,
+}
+
+impl MacroPackagesConfigNormalized {
+    pub(crate) fn all_macro_packages(&self) -> Vec<String> {
+        let mut all_macro_packages = Vec::with_capacity(self.core.len() + self.jsx.len());
+
+        for package in self.core.iter().chain(self.jsx.iter()) {
+            if all_macro_packages
+                .iter()
+                .any(|existing| existing == package)
+            {
+                continue;
+            }
+
+            all_macro_packages.push(package.clone());
+        }
+
+        all_macro_packages
+    }
+}
+
+impl Default for MacroPackagesConfigNormalized {
+    fn default() -> Self {
+        Self {
+            core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
+            jsx: vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
+        }
+    }
+}
+
 impl Default for RuntimeModulesConfigMapNormalized {
     fn default() -> Self {
         Self {
@@ -70,6 +108,12 @@ impl Default for RuntimeModulesConfigMapNormalized {
             trans: ("@lingui/react".into(), "Trans".into()),
             use_lingui: ("@lingui/react".into(), "useLingui".into()),
         }
+    }
+}
+
+impl LinguiOptions {
+    pub fn sync_derived_fields(&mut self) {
+        self.all_macro_packages = self.macro_packages.all_macro_packages();
     }
 }
 
@@ -86,12 +130,24 @@ impl LinguiJsOptions {
             other => other,
         };
 
+        let macro_packages = MacroPackagesConfigNormalized {
+            core: self
+                .core_package
+                .unwrap_or_else(|| MacroPackagesConfigNormalized::default().core),
+            jsx: self
+                .jsx_package
+                .unwrap_or_else(|| MacroPackagesConfigNormalized::default().jsx),
+        };
+        let all_macro_packages = macro_packages.all_macro_packages();
+
         LinguiOptions {
             descriptor_fields,
             use_lingui_v5_id_generation: self.use_lingui_v5_id_generation.unwrap_or(false),
             id_prefix_leader: self.id_prefix_leader.clone(),
             jsx_placeholder_attribute: self.jsx_placeholder_attribute.clone(),
             jsx_placeholder_defaults: self.jsx_placeholder_defaults.clone(),
+            macro_packages,
+            all_macro_packages,
             runtime_modules: RuntimeModulesConfigMapNormalized {
                 i18n: (
                     self.runtime_modules
@@ -145,6 +201,10 @@ pub struct LinguiOptions {
     #[serde(skip_serializing_if = "is_default")]
     pub jsx_placeholder_defaults: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "is_default")]
+    pub macro_packages: MacroPackagesConfigNormalized,
+    #[serde(skip)]
+    pub all_macro_packages: Vec<String>,
+    #[serde(skip_serializing_if = "is_default")]
     pub runtime_modules: RuntimeModulesConfigMapNormalized,
     #[serde(skip_serializing_if = "is_default")]
     pub use_lingui_v5_id_generation: bool,
@@ -152,12 +212,16 @@ pub struct LinguiOptions {
 
 impl Default for LinguiOptions {
     fn default() -> LinguiOptions {
+        let macro_packages = MacroPackagesConfigNormalized::default();
+
         LinguiOptions {
             descriptor_fields: DescriptorFields::All,
             use_lingui_v5_id_generation: false,
             id_prefix_leader: None,
             jsx_placeholder_attribute: None,
             jsx_placeholder_defaults: None,
+            all_macro_packages: macro_packages.all_macro_packages(),
+            macro_packages,
             runtime_modules: Default::default(),
         }
     }
@@ -197,6 +261,8 @@ mod lib_tests {
                         Some("myUseLingui".into())
                     )),
                 }),
+                core_package: None,
+                jsx_package: None,
                 descriptor_fields: None,
                 use_lingui_v5_id_generation: None,
                 id_prefix_leader: None,
@@ -225,6 +291,8 @@ mod lib_tests {
                     trans: None,
                     use_lingui: None,
                 }),
+                core_package: None,
+                jsx_package: None,
                 descriptor_fields: None,
                 use_lingui_v5_id_generation: None,
                 id_prefix_leader: None,
@@ -232,6 +300,54 @@ mod lib_tests {
                 jsx_placeholder_defaults: None,
             }
         )
+    }
+
+    #[test]
+    fn test_macro_package_defaults() {
+        let config = serde_json::from_str::<LinguiJsOptions>(
+            r#"{
+                "runtimeModules": {}
+               }"#,
+        )
+        .unwrap();
+
+        let options = config.into_options("development");
+        assert_eq!(
+            options.macro_packages,
+            MacroPackagesConfigNormalized {
+                core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
+                jsx: vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
+            }
+        );
+        assert_eq!(
+            options.all_macro_packages,
+            vec!["@lingui/macro", "@lingui/core/macro", "@lingui/react/macro"]
+        );
+    }
+
+    #[test]
+    fn test_macro_package_overrides() {
+        let config = serde_json::from_str::<LinguiJsOptions>(
+            r#"{
+                "corePackage": ["@acme/core/macro"],
+                "jsxPackage": ["@acme/react/macro"],
+                "runtimeModules": {}
+               }"#,
+        )
+        .unwrap();
+
+        let options = config.into_options("development");
+        assert_eq!(
+            options.macro_packages,
+            MacroPackagesConfigNormalized {
+                core: vec!["@acme/core/macro".into()],
+                jsx: vec!["@acme/react/macro".into()],
+            }
+        );
+        assert_eq!(
+            options.all_macro_packages,
+            vec!["@acme/core/macro", "@acme/react/macro"]
+        );
     }
 
     #[test]

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -103,3 +103,35 @@ to!(
       t`Text`
      "#
 );
+
+to!(
+    should_transform_custom_core_macro_package,
+    lingui_macro_plugin::LinguiOptions {
+        macro_packages: lingui_macro_plugin::MacroPackagesConfigNormalized {
+            core: vec!["@acme/core/macro".into()],
+            jsx: vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
+        },
+        ..Default::default()
+    },
+    r#"
+    import { t } from "@acme/core/macro";
+
+    t`Hello World!`;
+  "#
+);
+
+to!(
+    should_transform_custom_jsx_macro_package,
+    lingui_macro_plugin::LinguiOptions {
+        macro_packages: lingui_macro_plugin::MacroPackagesConfigNormalized {
+            core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
+            jsx: vec!["@acme/react/macro".into()],
+        },
+        ..Default::default()
+    },
+    r#"
+    import { Trans } from "@acme/react/macro";
+
+    ;<Trans>Hello!</Trans>
+  "#
+);

--- a/tests/snapshots/imports__should_transform_custom_core_macro_package.snap
+++ b/tests/snapshots/imports__should_transform_custom_core_macro_package.snap
@@ -1,0 +1,21 @@
+---
+source: tests/imports.rs
+info:
+  macro_packages:
+    core:
+      - "@acme/core/macro"
+    jsx:
+      - "@lingui/macro"
+      - "@lingui/react/macro"
+---
+import { t } from "@acme/core/macro";
+
+t`Hello World!`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as $_i18n } from "@lingui/core";
+$_i18n._(/*i18n*/ {
+    id: "0IkKj6",
+    message: "Hello World!"
+});

--- a/tests/snapshots/imports__should_transform_custom_jsx_macro_package.snap
+++ b/tests/snapshots/imports__should_transform_custom_jsx_macro_package.snap
@@ -1,0 +1,22 @@
+---
+source: tests/imports.rs
+info:
+  macro_packages:
+    core:
+      - "@lingui/macro"
+      - "@lingui/core/macro"
+    jsx:
+      - "@acme/react/macro"
+---
+import { Trans } from "@acme/react/macro";
+
+;<Trans>Hello!</Trans>
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as Trans_ } from "@lingui/react";
+;
+<Trans_ {.../*i18n*/ {
+    id: "mAYvqA",
+    message: "Hello!"
+}}/>;


### PR DESCRIPTION
I was trying to configure the [macro `corePackage`/`jsxPackage` settings](https://lingui.dev/ref/conf#macrocorepackage) available in the babel implementation, but noticed that they weren't supported by the SWC plugin. This PR should add support for them.

Disclaimer: My rust knowledge is very limited; most rust code was generated by GPT-5.4.