### PR TITLE
fix: normalize Trans prop in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ When using SWC directly via CLI or a JSON-only configuration, pass options manua
           {
             "runtimeModules": {
               "i18n": ["@lingui/core", "i18n"],
-              "trans": ["@lingui/react", "Trans"],
+              "Trans": ["@lingui/react", "Trans"],
               "useLingui": ["@lingui/react", "useLingui"]
             },
             "descriptorFields": "auto",

--- a/e2e/options.test.ts
+++ b/e2e/options.test.ts
@@ -21,13 +21,13 @@ describe("linguiMacroSwcPlugin", () => {
               "a": "link",
             },
             "runtimeModules": {
+              "Trans": [
+                "@acme/react",
+                "Trans",
+              ],
               "i18n": [
                 "@acme/core",
                 "i18n",
-              ],
-              "trans": [
-                "@acme/react",
-                "Trans",
               ],
               "useLingui": [
                 "@acme/react",
@@ -44,8 +44,7 @@ describe("linguiMacroSwcPlugin", () => {
 
   it("maps shared options from an explicit config path", () => {
     expect(linguiMacroSwcPlugin({}, {configPath: resolve(fixturesDir, "custom.config.js")})).toMatchInlineSnapshot(
-
-    `
+      `
       [
         "@lingui/swc-plugin",
         {
@@ -55,13 +54,13 @@ describe("linguiMacroSwcPlugin", () => {
             "strong": "bold",
           },
           "runtimeModules": {
+            "Trans": [
+              "@custom/react",
+              "CustomTrans",
+            ],
             "i18n": [
               "@custom/core",
               "customI18n",
-            ],
-            "trans": [
-              "@custom/react",
-              "CustomTrans",
             ],
             "useLingui": [
               "@custom/react",
@@ -79,7 +78,7 @@ describe("linguiMacroSwcPlugin", () => {
         {
           jsxPlaceholderAttribute: "data-test",
           runtimeModules: {
-            trans: ["@override/react", "OverrideTrans"],
+            Trans: ["@override/react", "OverrideTrans"],
           },
         },
         {configPath: resolve(fixturesDir, "custom.config.js")},
@@ -94,13 +93,13 @@ describe("linguiMacroSwcPlugin", () => {
             "strong": "bold",
           },
           "runtimeModules": {
+            "Trans": [
+              "@override/react",
+              "OverrideTrans",
+            ],
             "i18n": [
               "@custom/core",
               "customI18n",
-            ],
-            "trans": [
-              "@override/react",
-              "OverrideTrans",
             ],
             "useLingui": [
               "@custom/react",

--- a/src-js/options.ts
+++ b/src-js/options.ts
@@ -11,7 +11,7 @@ export type LinguiMacroOptions = {
   /** Overrides the runtime imports used by the plugin. Unlike the Babel macro configuration, must be passed as an object. */
   runtimeModules: {
     i18n: RuntimeModuleConfig
-    trans: RuntimeModuleConfig
+    Trans: RuntimeModuleConfig
     useLingui: RuntimeModuleConfig
   }
   /**
@@ -74,16 +74,13 @@ export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>
   const config = getConfig(
     configOptions,
   )
-  const {i18n, Trans, useLingui} = config.runtimeConfigModule
 
   const macroOptions: LinguiMacroOptions = {
     jsxPlaceholderAttribute: config.macro.jsxPlaceholderAttribute,
     jsxPlaceholderDefaults: config.macro.jsxPlaceholderDefaults,
     ...overrides,
     runtimeModules: {
-      i18n,
-      trans: Trans,
-      useLingui,
+      ...config.runtimeConfigModule,
       ...overrides?.runtimeModules,
     },
   } satisfies LinguiMacroOptions

--- a/src/options.rs
+++ b/src/options.rs
@@ -52,6 +52,7 @@ struct RuntimeModulesConfig(String, #[serde(default)] Option<String>);
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeModulesConfigMap {
     i18n: Option<RuntimeModulesConfig>,
+    #[serde(alias = "Trans")]
     trans: Option<RuntimeModulesConfig>,
     use_lingui: Option<RuntimeModulesConfig>,
 }
@@ -196,6 +197,37 @@ mod lib_tests {
                         "my-react".into(),
                         Some("myUseLingui".into())
                     )),
+                }),
+                descriptor_fields: None,
+                use_lingui_v5_id_generation: None,
+                id_prefix_leader: None,
+                jsx_placeholder_attribute: None,
+                jsx_placeholder_defaults: None,
+            }
+        )
+    }
+
+    #[test]
+    fn test_config_capital_trans() {
+        let config = serde_json::from_str::<LinguiJsOptions>(
+            r#"{
+                "runtimeModules": {
+                    "Trans": ["@lingui/react", "Trans"]
+                }
+               }"#,
+        )
+        .expect("invalid config for lingui-plugin");
+
+        assert_eq!(
+            config,
+            LinguiJsOptions {
+                runtime_modules: Some(RuntimeModulesConfigMap {
+                    i18n: None,
+                    trans: Some(RuntimeModulesConfig(
+                        "@lingui/react".into(),
+                        Some("Trans".into())
+                    )),
+                    use_lingui: None,
                 }),
                 descriptor_fields: None,
                 use_lingui_v5_id_generation: None,


### PR DESCRIPTION
i noticed a discrepency between Js and Rust macro versions. In js `runtimeModules.Trans` (from capital letter) in the rust version it was `runtimeModules.trans` from lowercase. This PR fixes this discrepency with backward compatibility. (swc macro now understands both `Trans/trans`)