### PR TITLE
fix: Return expected type from `linguiMacroSwcPlugin()`

### DIFF
--- a/src-js/options.ts
+++ b/src-js/options.ts
@@ -70,7 +70,7 @@ export type GetConfigOptions = {
  * @param overrides - Plugin options merged over values derived from the Lingui config.
  * @param configOptions - Controls how the Lingui config is discovered or loaded.
  */
-export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>, configOptions: GetConfigOptions = {}) {
+export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>, configOptions: GetConfigOptions = {}): [string, LinguiMacroOptions] {
   const config = getConfig(
     configOptions,
   )

--- a/src-js/options.ts
+++ b/src-js/options.ts
@@ -70,7 +70,7 @@ export type GetConfigOptions = {
  * @param overrides - Plugin options merged over values derived from the Lingui config.
  * @param configOptions - Controls how the Lingui config is discovered or loaded.
  */
-export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>, configOptions: GetConfigOptions = {}): [string, LinguiMacroOptions] {
+export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>, configOptions: GetConfigOptions = {}): [wasmPackage: string, config: LinguiMacroOptions] {
   const config = getConfig(
     configOptions,
   )


### PR DESCRIPTION
The return type of the new `linguiMacroSwcPlugin()` is `(string | LinguiMacroOptions)[]`, which raises TS errors when used in rsbuild.config.ts (and likely other SWC configs):
<img width="447" height="155" alt="image" src="https://github.com/user-attachments/assets/32c6d82b-c0cc-4c25-b988-edded284e00d" />

This PR adds an explicit return type to fix the issue.