### PR TITLE
fix: avoid dropping comment directives above macro imports

### DIFF
--- a/src/ast_utils.rs
+++ b/src/ast_utils.rs
@@ -204,18 +204,23 @@ pub fn create_key_value_prop(key: &str, value: Box<Expr>) -> PropOrSpread {
     })))
 }
 
-pub fn create_import(source: Atom, imported: IdentName, local: IdentName) -> ModuleItem {
+pub fn create_import(
+    source: Atom,
+    imported: IdentName,
+    local: IdentName,
+    span: Span,
+) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-        span: DUMMY_SP,
+        span,
         phase: ImportPhase::default(),
         specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-            span: DUMMY_SP,
+            span,
             local: local.into(),
             imported: Some(ModuleExportName::Ident(imported.into())),
             is_type_only: false,
         })],
         src: Box::new(Str {
-            span: DUMMY_SP,
+            span,
             value: source.to_string().into(),
             raw: None,
         }),

--- a/src/ast_utils.rs
+++ b/src/ast_utils.rs
@@ -204,23 +204,18 @@ pub fn create_key_value_prop(key: &str, value: Box<Expr>) -> PropOrSpread {
     })))
 }
 
-pub fn create_import(
-    source: Atom,
-    imported: IdentName,
-    local: IdentName,
-    span: Span,
-) -> ModuleItem {
+pub fn create_import(source: Atom, imported: IdentName, local: IdentName) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-        span,
+        span: DUMMY_SP,
         phase: ImportPhase::default(),
         specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-            span,
+            span: DUMMY_SP,
             local: local.into(),
             imported: Some(ModuleExportName::Ident(imported.into())),
             is_type_only: false,
         })],
         src: Box::new(Str {
-            span,
+            span: DUMMY_SP,
             value: source.to_string().into(),
             raw: None,
         }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,31 +376,35 @@ where
         let (trans_source, trans_export) = self.ctx.options.runtime_modules.trans.clone();
         let (use_lingui_source, use_lingui_export) =
             self.ctx.options.runtime_modules.use_lingui.clone();
-        let comment_directives = collect_lingui_directives(&n, &self.comments);
+
+        self.has_lingui_macro_imports = n.iter().any(|m| {
+            matches!(m,
+                ModuleItem::ModuleDecl(ModuleDecl::Import(imp))
+                if imp.src.value == "@lingui/macro"
+                    || imp.src.value == "@lingui/core/macro"
+                    || imp.src.value == "@lingui/react/macro"
+            )
+        });
+
+        if !self.has_lingui_macro_imports {
+            return n;
+        }
+
+        self.ctx
+            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
 
         let mut insert_index: usize = 0;
         let mut index = 0;
-        let mut removed_import_comments = vec![];
-        let mut import_span = None;
 
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
                 // drop macro imports
-                if &imp.src.value == "@lingui/macro"
-                    || &imp.src.value == "@lingui/core/macro"
-                    || &imp.src.value == "@lingui/react/macro"
+                if imp.src.value == "@lingui/macro"
+                    || imp.src.value == "@lingui/core/macro"
+                    || imp.src.value == "@lingui/react/macro"
                 {
-                    self.has_lingui_macro_imports = true;
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
-                    import_span.get_or_insert(imp.span);
-
-                    if let Some(comments) = &self.comments {
-                        if let Some(mut leading_comments) = comments.take_leading(imp.span.lo) {
-                            removed_import_comments.append(&mut leading_comments);
-                        }
-                    }
-
                     return false;
                 }
             }
@@ -408,18 +412,6 @@ where
             index += 1;
             true
         });
-
-        if !self.has_lingui_macro_imports {
-            return n;
-        }
-
-        let import_span = import_span.unwrap_or(DUMMY_SP);
-
-        if let Some(comments) = &self.comments {
-            comments.add_leading_comments(import_span.lo, removed_import_comments);
-        }
-
-        self.ctx.set_comment_directives(comment_directives);
 
         n = n.fold_children_with(self);
 
@@ -430,7 +422,6 @@ where
                     i18n_source.into(),
                     quote_ident!(i18n_export[..]),
                     self.ctx.runtime_idents.i18n.clone().into(),
-                    import_span,
                 ),
             );
         }
@@ -442,7 +433,6 @@ where
                     trans_source.into(),
                     quote_ident!(trans_export[..]),
                     self.ctx.runtime_idents.trans.clone(),
-                    import_span,
                 ),
             );
         }
@@ -454,7 +444,6 @@ where
                     use_lingui_source.into(),
                     quote_ident!(use_lingui_export[..]),
                     self.ctx.runtime_idents.use_lingui.clone(),
-                    import_span,
                 ),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,12 +376,12 @@ where
         let (trans_source, trans_export) = self.ctx.options.runtime_modules.trans.clone();
         let (use_lingui_source, use_lingui_export) =
             self.ctx.options.runtime_modules.use_lingui.clone();
+        let comment_directives = collect_lingui_directives(&n, &self.comments);
 
         let mut insert_index: usize = 0;
         let mut index = 0;
-
-        self.ctx
-            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
+        let mut removed_import_comments = vec![];
+        let mut import_span = None;
 
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
@@ -393,6 +393,14 @@ where
                     self.has_lingui_macro_imports = true;
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
+                    import_span.get_or_insert(imp.span);
+
+                    if let Some(comments) = &self.comments {
+                        if let Some(mut leading_comments) = comments.take_leading(imp.span.lo) {
+                            removed_import_comments.append(&mut leading_comments);
+                        }
+                    }
+
                     return false;
                 }
             }
@@ -405,6 +413,14 @@ where
             return n;
         }
 
+        let import_span = import_span.unwrap_or(DUMMY_SP);
+
+        if let Some(comments) = &self.comments {
+            comments.add_leading_comments(import_span.lo, removed_import_comments);
+        }
+
+        self.ctx.set_comment_directives(comment_directives);
+
         n = n.fold_children_with(self);
 
         if self.ctx.should_add_18n_import {
@@ -414,6 +430,7 @@ where
                     i18n_source.into(),
                     quote_ident!(i18n_export[..]),
                     self.ctx.runtime_idents.i18n.clone().into(),
+                    import_span,
                 ),
             );
         }
@@ -425,6 +442,7 @@ where
                     trans_source.into(),
                     quote_ident!(trans_export[..]),
                     self.ctx.runtime_idents.trans.clone(),
+                    import_span,
                 ),
             );
         }
@@ -436,6 +454,7 @@ where
                     use_lingui_source.into(),
                     quote_ident!(use_lingui_export[..]),
                     self.ctx.runtime_idents.use_lingui.clone(),
+                    import_span,
                 ),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,9 @@ where
         let mut insert_index: usize = 0;
         let mut index = 0;
 
+        self.ctx
+            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
+
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
                 // drop macro imports
@@ -401,9 +404,6 @@ where
         if !self.has_lingui_macro_imports {
             return n;
         }
-
-        self.ctx
-            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
 
         n = n.fold_children_with(self);
 

--- a/tests/lingui_directive.rs
+++ b/tests/lingui_directive.rs
@@ -31,6 +31,16 @@ to!(
 );
 
 to!(
+    js_t_with_directive_before_removed_macro_import_after_regular_import,
+    r#"
+        import foo from 'bar';
+        /* lingui-set context="test" */
+        import { t } from '@lingui/core/macro';
+        const msg = t`Success`
+    "#
+);
+
+to!(
     js_t_with_directive_context_and_comment,
     r#"
         import { t } from '@lingui/core/macro';

--- a/tests/lingui_directive.rs
+++ b/tests/lingui_directive.rs
@@ -22,6 +22,15 @@ to!(
 );
 
 to!(
+    js_t_with_top_of_file_directive_before_macro_import,
+    r#"
+        // lingui-set context="test"
+        import { t } from '@lingui/core/macro';
+        const msg = t`Success`
+    "#
+);
+
+to!(
     js_t_with_directive_context_and_comment,
     r#"
         import { t } from '@lingui/core/macro';

--- a/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
+++ b/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
@@ -9,7 +9,7 @@ const msg = t`Success`
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import foo from 'bar';
-/* lingui-set context="test" */ import { i18n as $_i18n } from "@lingui/core";
+import { i18n as $_i18n } from "@lingui/core";
 const msg = $_i18n._(/*i18n*/ {
     id: "vznMx_",
     message: "Success",

--- a/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
+++ b/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
@@ -1,0 +1,17 @@
+---
+source: tests/lingui_directive.rs
+---
+import foo from 'bar';
+/* lingui-set context="test" */
+import { t } from '@lingui/core/macro';
+const msg = t`Success`
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import foo from 'bar';
+/* lingui-set context="test" */ import { i18n as $_i18n } from "@lingui/core";
+const msg = $_i18n._(/*i18n*/ {
+    id: "vznMx_",
+    message: "Success",
+    context: "test"
+});

--- a/tests/snapshots/lingui_directive__js_t_with_top_of_file_directive_before_macro_import.snap
+++ b/tests/snapshots/lingui_directive__js_t_with_top_of_file_directive_before_macro_import.snap
@@ -1,0 +1,16 @@
+---
+source: tests/lingui_directive.rs
+---
+// lingui-set context="test"
+import { t } from '@lingui/core/macro';
+const msg = t`Success`
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+// lingui-set context="test"
+import { i18n as $_i18n } from "@lingui/core";
+const msg = $_i18n._(/*i18n*/ {
+    id: "vznMx_",
+    message: "Success",
+    context: "test"
+});


### PR DESCRIPTION
Fix a bug where `lingui-set`/`lingui-reset` comment directives would be ignored if they were inserted above the first Lingui macro import(s).

The failure happened becuase the plugin removed any leading comments along with the `@lingui/*/macro` imports, before collecting comment directives. In the case there the comment directive is attached to the import node, the directive was dropped before the plugin had a chance to read it.

A minimal failing case looked like this:

```ts
// lingui-set context="test"
import { t } from '@lingui/core/macro'
export const label = t`Fail`
```

Before this change, the generated message descriptor would not inherit the `context` or `comment` from `lingui-set`.

The fix is to collect Lingui comment directives before stripping Lingui macro imports from the module, and to re-insert any removed comments afterwards.