### PR TITLE
fix: handle lingui direcive comments above macro import

### DIFF
--- a/src/ast_utils.rs
+++ b/src/ast_utils.rs
@@ -204,18 +204,23 @@ pub fn create_key_value_prop(key: &str, value: Box<Expr>) -> PropOrSpread {
     })))
 }
 
-pub fn create_import(source: Atom, imported: IdentName, local: IdentName) -> ModuleItem {
+pub fn create_import(
+    source: Atom,
+    imported: IdentName,
+    local: IdentName,
+    span: Span,
+) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-        span: DUMMY_SP,
+        span,
         phase: ImportPhase::default(),
         specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-            span: DUMMY_SP,
+            span,
             local: local.into(),
             imported: Some(ModuleExportName::Ident(imported.into())),
             is_type_only: false,
         })],
         src: Box::new(Str {
-            span: DUMMY_SP,
+            span,
             value: source.to_string().into(),
             raw: None,
         }),

--- a/src/ast_utils.rs
+++ b/src/ast_utils.rs
@@ -204,23 +204,18 @@ pub fn create_key_value_prop(key: &str, value: Box<Expr>) -> PropOrSpread {
     })))
 }
 
-pub fn create_import(
-    source: Atom,
-    imported: IdentName,
-    local: IdentName,
-    span: Span,
-) -> ModuleItem {
+pub fn create_import(source: Atom, imported: IdentName, local: IdentName) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-        span,
+        span: DUMMY_SP,
         phase: ImportPhase::default(),
         specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-            span,
+            span: DUMMY_SP,
             local: local.into(),
             imported: Some(ModuleExportName::Ident(imported.into())),
             is_type_only: false,
         })],
         src: Box::new(Str {
-            span,
+            span: DUMMY_SP,
             value: source.to_string().into(),
             raw: None,
         }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ where
         self.has_lingui_macro_imports = n.iter().any(|m| {
             matches!(m,
                 ModuleItem::ModuleDecl(ModuleDecl::Import(imp))
-                if self.ctx.options.macro_packages.contains(&imp.src.value)
+                if self.ctx.options.macro_packages.contains(&imp.src.value.to_string_lossy())
             )
         });
 
@@ -397,7 +397,12 @@ where
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
                 // drop macro imports
-                if self.ctx.options.macro_packages.contains(&imp.src.value) {
+                if self
+                    .ctx
+                    .options
+                    .macro_packages
+                    .contains(&imp.src.value.to_string_lossy())
+                {
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
                     return false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,31 +376,35 @@ where
         let (trans_source, trans_export) = self.ctx.options.runtime_modules.trans.clone();
         let (use_lingui_source, use_lingui_export) =
             self.ctx.options.runtime_modules.use_lingui.clone();
-        let comment_directives = collect_lingui_directives(&n, &self.comments);
+
+        self.has_lingui_macro_imports = n.iter().any(|m| {
+            matches!(m,
+                ModuleItem::ModuleDecl(ModuleDecl::Import(imp))
+                if imp.src.value == "@lingui/macro"
+                    || imp.src.value == "@lingui/core/macro"
+                    || imp.src.value == "@lingui/react/macro"
+            )
+        });
+
+        if !self.has_lingui_macro_imports {
+            return n;
+        }
+
+        self.ctx
+            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
 
         let mut insert_index: usize = 0;
         let mut index = 0;
-        let mut removed_import_comments = vec![];
-        let mut import_span = None;
 
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
                 // drop macro imports
-                if &imp.src.value == "@lingui/macro"
-                    || &imp.src.value == "@lingui/core/macro"
-                    || &imp.src.value == "@lingui/react/macro"
+                if imp.src.value == "@lingui/macro"
+                    || imp.src.value == "@lingui/core/macro"
+                    || imp.src.value == "@lingui/react/macro"
                 {
-                    self.has_lingui_macro_imports = true;
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
-                    import_span.get_or_insert(imp.span);
-
-                    if let Some(comments) = &self.comments {
-                        if let Some(mut leading_comments) = comments.take_leading(imp.span.lo) {
-                            removed_import_comments.append(&mut leading_comments);
-                        }
-                    }
-
                     return false;
                 }
             }
@@ -408,18 +412,6 @@ where
             index += 1;
             true
         });
-
-        if !self.has_lingui_macro_imports {
-            return n;
-        }
-
-        let import_span = import_span.unwrap_or(DUMMY_SP);
-
-        if let Some(comments) = &self.comments {
-            comments.add_leading_comments(import_span.lo, removed_import_comments);
-        }
-
-        self.ctx.set_comment_directives(comment_directives);
 
         n = n.fold_children_with(self);
 
@@ -430,7 +422,6 @@ where
                     i18n_source.into(),
                     quote_ident!(i18n_export[..]),
                     self.ctx.runtime_idents.i18n.clone().into(),
-                    import_span,
                 ),
             );
         }
@@ -442,7 +433,6 @@ where
                     trans_source.into(),
                     quote_ident!(trans_export[..]),
                     self.ctx.runtime_idents.trans.clone(),
-                    import_span,
                 ),
             );
         }
@@ -454,7 +444,6 @@ where
                     use_lingui_source.into(),
                     quote_ident!(use_lingui_export[..]),
                     self.ctx.runtime_idents.use_lingui.clone(),
-                    import_span,
                 ),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,11 +380,7 @@ where
         self.has_lingui_macro_imports = n.iter().any(|m| {
             matches!(m,
                 ModuleItem::ModuleDecl(ModuleDecl::Import(imp))
-                if self
-                    .ctx
-                    .all_macro_packages
-                    .iter()
-                    .any(|package| imp.src.value == package.as_str())
+                if self.ctx.options.macro_packages.contains(&imp.src.value)
             )
         });
 
@@ -400,14 +396,8 @@ where
 
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
-
-              // drop macro imports
-                if  self
-                  .ctx
-                  .all_macro_packages
-                  .iter()
-                  .any(|package| imp.src.value == package.as_str());
-                {
+                // drop macro imports
+                if self.ctx.options.macro_packages.contains(&imp.src.value) {
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
                     return false;
@@ -549,8 +539,7 @@ where
 }
 
 pub use self::options::{
-    DescriptorFields, LinguiOptions, MacroPackagesConfigNormalized,
-    RuntimeModulesConfigMapNormalized,
+    DescriptorFields, LinguiOptions, MacroPackagesConfig, RuntimeModulesConfigMapNormalized,
 };
 
 #[plugin_transform]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,12 +376,12 @@ where
         let (trans_source, trans_export) = self.ctx.options.runtime_modules.trans.clone();
         let (use_lingui_source, use_lingui_export) =
             self.ctx.options.runtime_modules.use_lingui.clone();
+        let comment_directives = collect_lingui_directives(&n, &self.comments);
 
         let mut insert_index: usize = 0;
         let mut index = 0;
-
-        self.ctx
-            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
+        let mut removed_import_comments = vec![];
+        let mut import_span = None;
 
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
@@ -393,6 +393,14 @@ where
                     self.has_lingui_macro_imports = true;
                     self.ctx.register_macro_import(imp);
                     insert_index = index;
+                    import_span.get_or_insert(imp.span);
+
+                    if let Some(comments) = &self.comments {
+                        if let Some(mut leading_comments) = comments.take_leading(imp.span.lo) {
+                            removed_import_comments.append(&mut leading_comments);
+                        }
+                    }
+
                     return false;
                 }
             }
@@ -405,6 +413,14 @@ where
             return n;
         }
 
+        let import_span = import_span.unwrap_or(DUMMY_SP);
+
+        if let Some(comments) = &self.comments {
+            comments.add_leading_comments(import_span.lo, removed_import_comments);
+        }
+
+        self.ctx.set_comment_directives(comment_directives);
+
         n = n.fold_children_with(self);
 
         if self.ctx.should_add_18n_import {
@@ -414,6 +430,7 @@ where
                     i18n_source.into(),
                     quote_ident!(i18n_export[..]),
                     self.ctx.runtime_idents.i18n.clone().into(),
+                    import_span,
                 ),
             );
         }
@@ -425,6 +442,7 @@ where
                     trans_source.into(),
                     quote_ident!(trans_export[..]),
                     self.ctx.runtime_idents.trans.clone(),
+                    import_span,
                 ),
             );
         }
@@ -436,6 +454,7 @@ where
                     use_lingui_source.into(),
                     quote_ident!(use_lingui_export[..]),
                     self.ctx.runtime_idents.use_lingui.clone(),
+                    import_span,
                 ),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,9 @@ where
         let mut insert_index: usize = 0;
         let mut index = 0;
 
+        self.ctx
+            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
+
         n.retain(|m| {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(imp)) = m {
                 // drop macro imports
@@ -401,9 +404,6 @@ where
         if !self.has_lingui_macro_imports {
             return n;
         }
-
-        self.ctx
-            .set_comment_directives(collect_lingui_directives(&n, &self.comments));
 
         n = n.fold_children_with(self);
 

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -32,8 +32,6 @@ pub struct MacroCtx {
     // local name -> export name
     id_to_symbol_map: HashMap<Id, Atom>,
 
-    pub all_macro_packages: Vec<String>,
-
     pub should_add_18n_import: bool,
     pub should_add_trans_import: bool,
     pub should_add_uselingui_import: bool,
@@ -62,10 +60,7 @@ impl Default for RuntimeIdents {
 
 impl MacroCtx {
     pub fn new(options: LinguiOptions) -> MacroCtx {
-        let all_macro_packages = options.macro_packages.all_macro_packages();
-
         MacroCtx {
-            all_macro_packages,
             options,
             ..Default::default()
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -75,7 +75,7 @@ pub struct MacroPackagesConfig {
 }
 
 impl MacroPackagesConfig {
-    pub fn contains(&self, value: &impl PartialEq<str>) -> bool {
+    pub fn contains(&self, value: &str) -> bool {
         self.core.iter().any(|s| value == s.as_str())
             || self.jsx.iter().any(|s| value == s.as_str())
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -327,17 +327,11 @@ mod lib_tests {
             }
         );
 
-        assert!(options
-            .macro_packages
-            .contains(&"@lingui/macro".to_string()));
+        assert!(options.macro_packages.contains("@lingui/macro"));
 
-        assert!(options
-            .macro_packages
-            .contains(&"@lingui/core/macro".to_string()));
+        assert!(options.macro_packages.contains("@lingui/core/macro"));
 
-        assert!(options
-            .macro_packages
-            .contains(&"@lingui/react/macro".to_string()));
+        assert!(options.macro_packages.contains("@lingui/react/macro"));
     }
 
     #[test]
@@ -360,13 +354,9 @@ mod lib_tests {
             }
         );
 
-        assert!(options
-            .macro_packages
-            .contains(&"@acme/core/macro".to_string()));
+        assert!(options.macro_packages.contains("@acme/core/macro"));
 
-        assert!(options
-            .macro_packages
-            .contains(&"@acme/react/macro".to_string()));
+        assert!(options.macro_packages.contains("@acme/react/macro"));
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -69,31 +69,23 @@ pub struct RuntimeModulesConfigMapNormalized {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct MacroPackagesConfigNormalized {
+pub struct MacroPackagesConfig {
     pub core: Vec<String>,
     pub jsx: Vec<String>,
 }
 
-impl MacroPackagesConfigNormalized {
-    pub(crate) fn all_macro_packages(&self) -> Vec<String> {
-        let mut all_macro_packages = Vec::with_capacity(self.core.len() + self.jsx.len());
+impl MacroPackagesConfig {
+    pub fn new(core: Vec<String>, jsx: Vec<String>) -> Self {
+        Self { core, jsx }
+    }
 
-        for package in self.core.iter().chain(self.jsx.iter()) {
-            if all_macro_packages
-                .iter()
-                .any(|existing| existing == package)
-            {
-                continue;
-            }
-
-            all_macro_packages.push(package.clone());
-        }
-
-        all_macro_packages
+    pub fn contains(&self, value: &impl PartialEq<str>) -> bool {
+        self.core.iter().any(|s| value == s.as_str())
+            || self.jsx.iter().any(|s| value == s.as_str())
     }
 }
 
-impl Default for MacroPackagesConfigNormalized {
+impl Default for MacroPackagesConfig {
     fn default() -> Self {
         Self {
             core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
@@ -125,22 +117,20 @@ impl LinguiJsOptions {
             other => other,
         };
 
-        let macro_packages = MacroPackagesConfigNormalized {
-            core: self
-                .core_package
-                .unwrap_or_else(|| MacroPackagesConfigNormalized::default().core),
-            jsx: self
-                .jsx_package
-                .unwrap_or_else(|| MacroPackagesConfigNormalized::default().jsx),
-        };
-
         LinguiOptions {
             descriptor_fields,
             use_lingui_v5_id_generation: self.use_lingui_v5_id_generation.unwrap_or(false),
             id_prefix_leader: self.id_prefix_leader.clone(),
             jsx_placeholder_attribute: self.jsx_placeholder_attribute.clone(),
             jsx_placeholder_defaults: self.jsx_placeholder_defaults.clone(),
-            macro_packages,
+            macro_packages: MacroPackagesConfig {
+                core: self
+                    .core_package
+                    .unwrap_or_else(|| MacroPackagesConfig::default().core),
+                jsx: self
+                    .jsx_package
+                    .unwrap_or_else(|| MacroPackagesConfig::default().jsx),
+            },
             runtime_modules: RuntimeModulesConfigMapNormalized {
                 i18n: (
                     self.runtime_modules
@@ -194,7 +184,7 @@ pub struct LinguiOptions {
     #[serde(skip_serializing_if = "is_default")]
     pub jsx_placeholder_defaults: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "is_default")]
-    pub macro_packages: MacroPackagesConfigNormalized,
+    pub macro_packages: MacroPackagesConfig,
     #[serde(skip_serializing_if = "is_default")]
     pub runtime_modules: RuntimeModulesConfigMapNormalized,
     #[serde(skip_serializing_if = "is_default")]
@@ -287,6 +277,8 @@ mod lib_tests {
                 id_prefix_leader: None,
                 jsx_placeholder_attribute: None,
                 jsx_placeholder_defaults: None,
+                core_package: None,
+                jsx_package: None,
             }
         )
     }
@@ -333,15 +325,23 @@ mod lib_tests {
         let options = config.into_options("development");
         assert_eq!(
             options.macro_packages,
-            MacroPackagesConfigNormalized {
+            MacroPackagesConfig {
                 core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
                 jsx: vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
             }
         );
-        assert_eq!(
-            options.macro_packages.all_macro_packages(),
-            vec!["@lingui/macro", "@lingui/core/macro", "@lingui/react/macro"]
-        );
+
+        assert!(options
+            .macro_packages
+            .contains(&"@lingui/macro".to_string()));
+
+        assert!(options
+            .macro_packages
+            .contains(&"@lingui/core/macro".to_string()));
+
+        assert!(options
+            .macro_packages
+            .contains(&"@lingui/react/macro".to_string()));
     }
 
     #[test]
@@ -358,15 +358,19 @@ mod lib_tests {
         let options = config.into_options("development");
         assert_eq!(
             options.macro_packages,
-            MacroPackagesConfigNormalized {
+            MacroPackagesConfig {
                 core: vec!["@acme/core/macro".into()],
                 jsx: vec!["@acme/react/macro".into()],
             }
         );
-        assert_eq!(
-            options.macro_packages.all_macro_packages(),
-            vec!["@acme/core/macro", "@acme/react/macro"]
-        );
+
+        assert!(options
+            .macro_packages
+            .contains(&"@acme/core/macro".to_string()));
+
+        assert!(options
+            .macro_packages
+            .contains(&"@acme/react/macro".to_string()));
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -75,10 +75,6 @@ pub struct MacroPackagesConfig {
 }
 
 impl MacroPackagesConfig {
-    pub fn new(core: Vec<String>, jsx: Vec<String>) -> Self {
-        Self { core, jsx }
-    }
-
     pub fn contains(&self, value: &impl PartialEq<str>) -> bool {
         self.core.iter().any(|s| value == s.as_str())
             || self.jsx.iter().any(|s| value == s.as_str())

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -107,10 +107,10 @@ to!(
 to!(
     should_transform_custom_core_macro_package,
     lingui_macro_plugin::LinguiOptions {
-        macro_packages: lingui_macro_plugin::MacroPackagesConfig::new(
-            vec!["@acme/core/macro".into()],
-            vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
-        ),
+        macro_packages: lingui_macro_plugin::MacroPackagesConfig {
+            core: vec!["@acme/core/macro".into()],
+            jsx: vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
+        },
         ..Default::default()
     },
     r#"
@@ -123,10 +123,10 @@ to!(
 to!(
     should_transform_custom_jsx_macro_package,
     lingui_macro_plugin::LinguiOptions {
-        macro_packages: lingui_macro_plugin::MacroPackagesConfig::new(
-            vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
-            vec!["@acme/react/macro".into()],
-        ),
+        macro_packages: lingui_macro_plugin::MacroPackagesConfig {
+            core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
+            jsx: vec!["@acme/react/macro".into()],
+        },
         ..Default::default()
     },
     r#"

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -107,10 +107,10 @@ to!(
 to!(
     should_transform_custom_core_macro_package,
     lingui_macro_plugin::LinguiOptions {
-        macro_packages: lingui_macro_plugin::MacroPackagesConfigNormalized {
-            core: vec!["@acme/core/macro".into()],
-            jsx: vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
-        },
+        macro_packages: lingui_macro_plugin::MacroPackagesConfig::new(
+            vec!["@acme/core/macro".into()],
+            vec!["@lingui/macro".into(), "@lingui/react/macro".into()],
+        ),
         ..Default::default()
     },
     r#"
@@ -123,10 +123,10 @@ to!(
 to!(
     should_transform_custom_jsx_macro_package,
     lingui_macro_plugin::LinguiOptions {
-        macro_packages: lingui_macro_plugin::MacroPackagesConfigNormalized {
-            core: vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
-            jsx: vec!["@acme/react/macro".into()],
-        },
+        macro_packages: lingui_macro_plugin::MacroPackagesConfig::new(
+            vec!["@lingui/macro".into(), "@lingui/core/macro".into()],
+            vec!["@acme/react/macro".into()],
+        ),
         ..Default::default()
     },
     r#"

--- a/tests/lingui_directive.rs
+++ b/tests/lingui_directive.rs
@@ -31,6 +31,16 @@ to!(
 );
 
 to!(
+    js_t_with_directive_before_removed_macro_import_after_regular_import,
+    r#"
+        import foo from 'bar';
+        /* lingui-set context="test" */
+        import { t } from '@lingui/core/macro';
+        const msg = t`Success`
+    "#
+);
+
+to!(
     js_t_with_directive_context_and_comment,
     r#"
         import { t } from '@lingui/core/macro';

--- a/tests/lingui_directive.rs
+++ b/tests/lingui_directive.rs
@@ -22,6 +22,15 @@ to!(
 );
 
 to!(
+    js_t_with_top_of_file_directive_before_macro_import,
+    r#"
+        // lingui-set context="test"
+        import { t } from '@lingui/core/macro';
+        const msg = t`Success`
+    "#
+);
+
+to!(
     js_t_with_directive_context_and_comment,
     r#"
         import { t } from '@lingui/core/macro';

--- a/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
+++ b/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
@@ -9,7 +9,7 @@ const msg = t`Success`
 ↓ ↓ ↓ ↓ ↓ ↓
 
 import foo from 'bar';
-/* lingui-set context="test" */ import { i18n as $_i18n } from "@lingui/core";
+import { i18n as $_i18n } from "@lingui/core";
 const msg = $_i18n._(/*i18n*/ {
     id: "vznMx_",
     message: "Success",

--- a/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
+++ b/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
@@ -1,0 +1,17 @@
+---
+source: tests/lingui_directive.rs
+---
+import foo from 'bar';
+/* lingui-set context="test" */
+import { t } from '@lingui/core/macro';
+const msg = t`Success`
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import foo from 'bar';
+/* lingui-set context="test" */ import { i18n as $_i18n } from "@lingui/core";
+const msg = $_i18n._(/*i18n*/ {
+    id: "vznMx_",
+    message: "Success",
+    context: "test"
+});

--- a/tests/snapshots/lingui_directive__js_t_with_top_of_file_directive_before_macro_import.snap
+++ b/tests/snapshots/lingui_directive__js_t_with_top_of_file_directive_before_macro_import.snap
@@ -1,0 +1,16 @@
+---
+source: tests/lingui_directive.rs
+---
+// lingui-set context="test"
+import { t } from '@lingui/core/macro';
+const msg = t`Success`
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+// lingui-set context="test"
+import { i18n as $_i18n } from "@lingui/core";
+const msg = $_i18n._(/*i18n*/ {
+    id: "vznMx_",
+    message: "Success",
+    context: "test"
+});


### PR DESCRIPTION
This is a continuation of https://github.com/lingui/swc-plugin/pull/221 and since the changes went beyond the original scope i decided to open a separate PR on behalf of me. 

This PR doing two things: 

- Fix the issie described in #221 - handles directives if they specified above the macro imports
- Refactor recently merged core packages configuration https://github.com/lingui/swc-plugin/pull/218

Note, rised by @mogelbrod issue is out of scope of this fix

> > This implementation does not cover keeping comments in the resulting output. Because we literally don't need them in the produced code.
> 
> The comments above the lingui imports may be comment directives for other libraries, so I think it's necessary to keep them. Otherwise we risk breaking compilation for other libraries just like we do for lingui without this patch.

This issue was before directives feature was introduced and out of scope of this fix.  I also thinking that this is an extremely edge case. I would like to fix it only in case if actual users would complain about this. Because the fix  is not straightforward - doesn't cover all the cases and make code more complicated and harder to understand. 