### PR TITLE
feat: expose `mapOptions` util and add `idPrefixLeader` to mapper

### DIFF
--- a/e2e/fixtures/lingui-options/custom.config.js
+++ b/e2e/fixtures/lingui-options/custom.config.js
@@ -1,4 +1,6 @@
-export default {
+import {defineConfig} from "@lingui/conf";
+
+export default defineConfig({
   locales: ["en"],
   sourceLocale: "en",
   runtimeConfigModule: {
@@ -7,6 +9,7 @@ export default {
     useLingui: ["@custom/react", "useCustomLingui"],
   },
   macro: {
+    idPrefixLeader: '.',
     corePackage: ["@custom/core/macro"],
     jsxPackage: ["@custom/react/macro"],
     jsxPlaceholderAttribute: "data-i18n",
@@ -15,4 +18,4 @@ export default {
       strong: "bold",
     },
   },
-}
+})

--- a/e2e/fixtures/lingui-options/lingui.config.js
+++ b/e2e/fixtures/lingui-options/lingui.config.js
@@ -1,4 +1,6 @@
-export default {
+import {defineConfig} from "@lingui/conf";
+
+export default defineConfig({
   locales: ["en"],
   sourceLocale: "en",
   runtimeConfigModule: {
@@ -7,9 +9,12 @@ export default {
     useLingui: ["@acme/react", "useLingui"],
   },
   macro: {
+    idPrefixLeader: '.',
+    corePackage: ["@acme/core/macro"],
+    jsxPackage: ["@acme/jsx/macro"],
     jsxPlaceholderAttribute: "_t",
     jsxPlaceholderDefaults: {
       a: "link",
     },
   },
-}
+})

--- a/e2e/options.test.ts
+++ b/e2e/options.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from "vitest"
 import {resolve} from "node:path"
-
-import {linguiMacroSwcPlugin} from "../src-js/options"
+import {makeConfig} from '@lingui/conf'
+import {linguiMacroSwcPlugin, mapOptions} from "../src-js/options"
 
 const fixturesDir = resolve(import.meta.dirname, "fixtures/lingui-options")
 
@@ -17,10 +17,11 @@ describe("linguiMacroSwcPlugin", () => {
           "@lingui/swc-plugin",
           {
             "corePackage": [
-              "@lingui/core/macro",
+              "@acme/core/macro",
             ],
+            "idPrefixLeader": ".",
             "jsxPackage": [
-              "@lingui/react/macro",
+              "@acme/jsx/macro",
             ],
             "jsxPlaceholderAttribute": "_t",
             "jsxPlaceholderDefaults": {
@@ -57,6 +58,7 @@ describe("linguiMacroSwcPlugin", () => {
           "corePackage": [
             "@custom/core/macro",
           ],
+          "idPrefixLeader": ".",
           "jsxPackage": [
             "@custom/react/macro",
           ],
@@ -104,6 +106,7 @@ describe("linguiMacroSwcPlugin", () => {
           "corePackage": [
             "@override/core/macro",
           ],
+          "idPrefixLeader": ".",
           "jsxPackage": [
             "@override/react/macro",
           ],
@@ -129,5 +132,60 @@ describe("linguiMacroSwcPlugin", () => {
         },
       ]
     `)
+  })
+})
+
+describe('mapOptions', () => {
+  it('should map Lingui config options to SWC Wasm Plugin options', () => {
+    const config = makeConfig({
+      locales: ["en"],
+      sourceLocale: "en",
+      runtimeConfigModule: {
+        i18n: ["@custom/core", "customI18n"],
+        Trans: ["@custom/react", "CustomTrans"],
+        useLingui: ["@custom/react", "useCustomLingui"],
+      },
+      macro: {
+        idPrefixLeader: '.',
+        corePackage: ["@custom/core/macro"],
+        jsxPackage: ["@custom/react/macro"],
+        jsxPlaceholderAttribute: "data-i18n",
+        jsxPlaceholderDefaults: {
+          a: "anchor",
+          strong: "bold",
+        },
+      },
+    })
+
+    expect(mapOptions(config)).toMatchInlineSnapshot(`
+      {
+        "corePackage": [
+          "@custom/core/macro",
+        ],
+        "idPrefixLeader": ".",
+        "jsxPackage": [
+          "@custom/react/macro",
+        ],
+        "jsxPlaceholderAttribute": "data-i18n",
+        "jsxPlaceholderDefaults": {
+          "a": "anchor",
+          "strong": "bold",
+        },
+        "runtimeModules": {
+          "Trans": [
+            "@custom/react",
+            "CustomTrans",
+          ],
+          "i18n": [
+            "@custom/core",
+            "customI18n",
+          ],
+          "useLingui": [
+            "@custom/react",
+            "useCustomLingui",
+          ],
+        },
+      }
+    `);
   })
 })

--- a/src-js/options.ts
+++ b/src-js/options.ts
@@ -1,4 +1,4 @@
-import {getConfig} from "@lingui/conf"
+import {getConfig, LinguiConfigNormalized} from "@lingui/conf"
 
 export type RuntimeModuleConfig = readonly [modulePath: string, exportName?: string];
 
@@ -39,7 +39,7 @@ export type LinguiMacroOptions = {
 }
 
 /** Makes all properties in `T` optional, recursing into nested objects but preserving tuples/arrays as-is. */
-export type DeepPartial<T> = {
+type DeepPartial<T> = {
   [Key in keyof T]?: T[Key] extends readonly unknown[]
     ? T[Key]
     : T[Key] extends object
@@ -79,17 +79,23 @@ export function linguiMacroSwcPlugin(overrides?: DeepPartial<LinguiMacroOptions>
     configOptions,
   )
 
-  const macroOptions: LinguiMacroOptions = {
-    corePackage: config.macro.corePackage,
-    jsxPackage: config.macro.jsxPackage,
-    jsxPlaceholderAttribute: config.macro.jsxPlaceholderAttribute,
-    jsxPlaceholderDefaults: config.macro.jsxPlaceholderDefaults,
+  return ["@lingui/swc-plugin", mapOptions(config, overrides)];
+}
+
+/**
+ * Maps relevant options from the Lingui config to the SWC plugin format
+ */
+export function mapOptions(linguiConfig: LinguiConfigNormalized, overrides?: DeepPartial<LinguiMacroOptions>): LinguiMacroOptions {
+  return {
+    corePackage: linguiConfig.macro.corePackage,
+    jsxPackage: linguiConfig.macro.jsxPackage,
+    jsxPlaceholderAttribute: linguiConfig.macro.jsxPlaceholderAttribute,
+    jsxPlaceholderDefaults: linguiConfig.macro.jsxPlaceholderDefaults,
+    idPrefixLeader: linguiConfig.macro.idPrefixLeader,
     ...overrides,
     runtimeModules: {
-      ...config.runtimeConfigModule,
+      ...linguiConfig.runtimeConfigModule,
       ...overrides?.runtimeModules,
     },
-  } satisfies LinguiMacroOptions
-
-  return ["@lingui/swc-plugin", macroOptions];
+  }
 }


### PR DESCRIPTION
 `idPrefixLeader` was not mapped in the `linguiMacroSwcPlugin`, i added this to the mapping. 

I also exposed a `mapOptions` helper which is lower level and i'm going to use it in the rust extractor