### PR TITLE
perf: improve plugin performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,8 +792,6 @@ version = "6.3.0"
 dependencies = [
  "data-encoding",
  "insta",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,21 +7,15 @@ edition = "2021"
 crate-type = ["cdylib", 'rlib']
 
 [profile.release]
-# This removes more dead code
 codegen-units = 1
 lto = false
-# Optimize for size
-opt-level = "s"
-# Optimize for performance, this is default so you don't need to specify it
-# opt-level = "z"
+opt-level = 3
 
 [dependencies]
 data-encoding = "2.11.0"
 sha2 = "0.11.0"
 serde = "1.0.228"
 serde_json = "1.0.149"
-regex = "1.12.3"
-once_cell = "1.21.4"
 swc_core = { version = "66.0.3", features = [
   "ecma_plugin_transform",
   "ecma_utils",

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,10 +10,34 @@ use swc_core::{
     ecma::ast::*,
 };
 
-static NUMERIC_REGEX: once_cell::sync::Lazy<regex::Regex> =
-    once_cell::sync::Lazy::new(|| regex::Regex::new(r"^\d+$").unwrap());
-static VALID_NAME_REGEX: once_cell::sync::Lazy<regex::Regex> =
-    once_cell::sync::Lazy::new(|| regex::Regex::new(r"^[a-zA-Z_]([\w.-]*\w)?$").unwrap());
+fn is_numeric(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn is_valid_placeholder_name(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+
+    let bytes = s.as_bytes();
+    let first = bytes[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return false;
+    }
+
+    if bytes.len() == 1 {
+        return true;
+    }
+
+    let last = bytes[bytes.len() - 1];
+    if !(last.is_ascii_alphanumeric() || last == b'_') {
+        return false;
+    }
+
+    bytes[1..bytes.len() - 1]
+        .iter()
+        .all(|&b| b.is_ascii_alphanumeric() || b == b'_' || b == b'.' || b == b'-')
+}
 
 fn dedup_values(mut v: Vec<ValueWithPlaceholder>) -> Vec<ValueWithPlaceholder> {
     let mut uniques = HashSet::new();
@@ -195,14 +219,14 @@ impl<'a> MessageBuilder<'a> {
         }
 
         let name = if let Some(n) = base_name {
-            if NUMERIC_REGEX.is_match(&n) {
+            if is_numeric(&n) {
                 swc_core::plugin::errors::HANDLER.with(|h| {
                     h.struct_span_err(
                         el.span,
                         &format!("Placeholder name `{n}` is not allowed because it conflicts with auto-generated numeric placeholders. Use a non-numeric name instead."),
                     ).emit();
                 });
-            } else if !VALID_NAME_REGEX.is_match(&n) {
+            } else if !is_valid_placeholder_name(&n) {
                 swc_core::plugin::errors::HANDLER.with(|h| {
                     h.struct_span_err(
                         el.span,

--- a/src/comment_directive/mod.rs
+++ b/src/comment_directive/mod.rs
@@ -1,14 +1,8 @@
 mod source_scanner;
 
-use once_cell::sync::Lazy;
-use regex::Regex;
 use source_scanner::{scan_source_comments, CommentKind};
 use swc_core::common::{BytePos, Span};
 use swc_core::plugin::errors::HANDLER;
-
-static DIRECTIVE_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(lingui-(?:set|reset))(?:\s|$)(.*)").unwrap());
-static TOKEN_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\s+|(\w+)(?:="([^"]*)")?"#).unwrap());
 
 fn is_lingui_directive_prefix(comment: &str) -> bool {
     comment.starts_with("lingui-set") || comment.starts_with("lingui-reset")
@@ -103,39 +97,75 @@ fn parse_value_update(value: &str) -> DirectiveValueUpdate {
 fn parse_lingui_directive(comment_value: &str) -> Result<Option<ParsedDirective>, String> {
     let trimmed = comment_value.trim();
 
-    let Some(directive_match) = DIRECTIVE_RE.captures(trimmed) else {
+    let (directive_name, rest) = if let Some(rest) = trimmed.strip_prefix("lingui-set") {
+        ("lingui-set", rest)
+    } else if let Some(rest) = trimmed.strip_prefix("lingui-reset") {
+        ("lingui-reset", rest)
+    } else {
         return Ok(None);
     };
 
-    let directive_name = directive_match.get(1).unwrap().as_str();
-    let reset = directive_name == "lingui-reset";
-    let rest = directive_match
-        .get(2)
-        .map(|m| m.as_str().trim())
-        .unwrap_or_default();
+    if !rest.is_empty() && !rest.starts_with(char::is_whitespace) {
+        return Ok(None);
+    }
 
-    let mut consumed = 0usize;
+    let reset = directive_name == "lingui-reset";
+    let rest = rest.trim();
+
     let mut values = DirectiveUpdate::default();
     let mut has_params = false;
+    let mut pos = 0;
+    let rest_bytes = rest.as_bytes();
 
-    for capture in TOKEN_RE.captures_iter(rest) {
-        let full = capture.get(0).unwrap();
-        if full.start() != consumed {
+    while pos < rest_bytes.len() {
+        // skip whitespace
+        while pos < rest_bytes.len() && rest_bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if pos >= rest_bytes.len() {
+            break;
+        }
+
+        // parse key (word chars)
+        let key_start = pos;
+        while pos < rest_bytes.len()
+            && (rest_bytes[pos].is_ascii_alphanumeric() || rest_bytes[pos] == b'_')
+        {
+            pos += 1;
+        }
+        if pos == key_start {
             return Err(format!(
                 "`{directive_name}` directive has invalid syntax: {trimmed}"
             ));
         }
-        consumed = full.end();
+        let key = &rest[key_start..pos];
 
-        let Some(key) = capture.get(1).map(|m| m.as_str()) else {
-            continue;
-        };
-
-        let Some(value) = capture.get(2).map(|m| m.as_str()) else {
+        // expect ="..."
+        if pos >= rest_bytes.len() || rest_bytes[pos] != b'=' {
             return Err(format!(
                 "`{directive_name}` directive: \"{key}\" requires a value, e.g. {key}=\"...\""
             ));
-        };
+        }
+        pos += 1; // skip '='
+
+        if pos >= rest_bytes.len() || rest_bytes[pos] != b'"' {
+            return Err(format!(
+                "`{directive_name}` directive: \"{key}\" requires a value, e.g. {key}=\"...\""
+            ));
+        }
+        pos += 1; // skip opening '"'
+
+        let value_start = pos;
+        while pos < rest_bytes.len() && rest_bytes[pos] != b'"' {
+            pos += 1;
+        }
+        if pos >= rest_bytes.len() {
+            return Err(format!(
+                "`{directive_name}` directive has invalid syntax: {trimmed}"
+            ));
+        }
+        let value = &rest[value_start..pos];
+        pos += 1; // skip closing '"'
 
         has_params = true;
         let update = parse_value_update(value);
@@ -146,22 +176,16 @@ fn parse_lingui_directive(comment_value: &str) -> Result<Option<ParsedDirective>
             "idPrefix" => values.id_prefix = Some(update),
             _ => {
                 return Err(format!(
-          "`{directive_name}` directive has unknown param \"{key}\". Valid params: context, comment, idPrefix"
-        ));
+                    "`{directive_name}` directive has unknown param \"{key}\". Valid params: context, comment, idPrefix"
+                ));
             }
         }
     }
 
-    if consumed != rest.len() {
-        return Err(format!(
-            "`{directive_name}` directive has invalid syntax: {trimmed}"
-        ));
-    }
-
     if !has_params && !reset {
         return Err(format!(
-      "`{directive_name}` directive requires at least one param. Valid params: context, comment, idPrefix"
-    ));
+            "`{directive_name}` directive requires at least one param. Valid params: context, comment, idPrefix"
+        ));
     }
 
     Ok(Some(ParsedDirective { reset, values }))

--- a/src/generate_id.rs
+++ b/src/generate_id.rs
@@ -1,11 +1,11 @@
 use data_encoding::{BASE64, BASE64URL};
 use sha2::{Digest, Sha256};
 
-const UNIT_SEPARATOR: &char = &'\u{001F}';
-
 pub fn generate_message_id(message: &str, context: &str, use_lingui_v5: bool) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(format!("{message}{UNIT_SEPARATOR}{context}"));
+    hasher.update(message.as_bytes());
+    hasher.update(&[0x1F]); // UNIT_SEPARATOR
+    hasher.update(context.as_bytes());
 
     let result = hasher.finalize();
 

--- a/src/generate_id.rs
+++ b/src/generate_id.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 pub fn generate_message_id(message: &str, context: &str, use_lingui_v5: bool) -> String {
     let mut hasher = Sha256::new();
     hasher.update(message.as_bytes());
-    hasher.update(&[0x1F]); // UNIT_SEPARATOR
+    hasher.update([0x1F]); // UNIT_SEPARATOR
     hasher.update(context.as_bytes());
 
     let result = hasher.finalize();

--- a/src/jsx_visitor.rs
+++ b/src/jsx_visitor.rs
@@ -1,8 +1,6 @@
 use crate::ast_utils::{get_jsx_attr, get_jsx_attr_value_as_string};
 use crate::macro_utils::MacroCtx;
 use crate::tokens::{CaseOrOffset, ChoiceCase, IcuChoice, MsgToken, TagOpening};
-use once_cell::sync::Lazy;
-use regex::Regex;
 use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::*;
 use swc_core::ecma::atoms::Atom;
@@ -23,26 +21,39 @@ impl<'a> TransJSXVisitor<'a> {
     }
 }
 
-static PLURAL_OPTIONS_WHITELIST: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(_[\d\w]+|zero|one|two|few|many|other)").unwrap());
-static NUM_OPTION: Lazy<Regex> = Lazy::new(|| Regex::new(r"_(\d+)").unwrap());
-static WORD_OPTION: Lazy<Regex> = Lazy::new(|| Regex::new(r"_(\w+)").unwrap());
-
-// const pluralRuleRe = /(_[\d\w]+|zero|one|two|few|many|other)/
-// const jsx2icuExactChoice = (value: string) => value.replace(/_(\d+)/, "=$1").replace(/_(\w+)/, "$1")
-
-static TRIM_START: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[ ]+").unwrap());
-static TRIM_END: Lazy<Regex> = Lazy::new(|| Regex::new(r"[ ]+$").unwrap());
-
 // taken from babel repo -> packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts
+fn split_lines(value: &str) -> Vec<&str> {
+    let mut lines = Vec::new();
+    let mut start = 0;
+    let bytes = value.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        if bytes[i] == b'\r' {
+            lines.push(&value[start..i]);
+            if i + 1 < len && bytes[i + 1] == b'\n' {
+                i += 1;
+            }
+            start = i + 1;
+        } else if bytes[i] == b'\n' {
+            lines.push(&value[start..i]);
+            start = i + 1;
+        }
+        i += 1;
+    }
+
+    lines.push(&value[start..]);
+    lines
+}
+
 fn clean_jsx_element_literal_child(value: &str) -> String {
-    let lines: Vec<&str> = Regex::new(r"\r\n|\n|\r").unwrap().split(value).collect();
     let mut last_non_empty_line = 0;
 
-    let re_non_space = Regex::new(r"[^\t ]").unwrap();
+    let lines = split_lines(value);
 
     for (i, line) in lines.iter().enumerate() {
-        if re_non_space.is_match(line) {
+        if line.bytes().any(|b| b != b'\t' && b != b' ') {
             last_non_empty_line = i;
         }
     }
@@ -55,16 +66,16 @@ fn clean_jsx_element_literal_child(value: &str) -> String {
         let is_last_non_empty_line = i == last_non_empty_line;
 
         // replace rendered whitespace tabs with spaces
-        let mut trimmed_line = line.replace("\t", " ");
+        let mut trimmed_line = line.replace('\t', " ");
 
         // trim whitespace touching a newline
         if !is_first_line {
-            trimmed_line = TRIM_START.replace(&trimmed_line, "").to_string();
+            trimmed_line = trimmed_line.trim_start_matches(' ').to_string();
         }
 
         // trim whitespace touching an endline
         if !is_last_line {
-            trimmed_line = TRIM_END.replace(&trimmed_line, "").to_string();
+            trimmed_line = trimmed_line.trim_end_matches(' ').to_string();
         }
 
         if !trimmed_line.is_empty() {
@@ -80,14 +91,23 @@ fn clean_jsx_element_literal_child(value: &str) -> String {
 }
 
 fn is_allowed_plural_option(key: &str) -> Option<Atom> {
-    if PLURAL_OPTIONS_WHITELIST.is_match(key) {
-        let key = NUM_OPTION.replace(key, "=$1");
-        let key = WORD_OPTION.replace(&key, "$1");
-
-        return Some(key.to_string().into());
+    match key {
+        "zero" | "one" | "two" | "few" | "many" | "other" => Some(key.into()),
+        _ if key.starts_with('_') && key.len() > 1 => {
+            let suffix = &key[1..];
+            if suffix.bytes().all(|b| b.is_ascii_digit()) {
+                Some(format!("={suffix}").into())
+            } else if suffix
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+            {
+                Some(suffix.into())
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
-
-    None
 }
 
 impl TransJSXVisitor<'_> {


### PR DESCRIPTION
```
$ yarn bench --scenario macro-transform

══════════════════════════════════════════════════════════════
  Lingui Benchmark — Preset: medium
  1000 files · 10.0k messages · 5 locales
  Node v24.13.1 · darwin arm64
  Apple M3 Max (16 cores)
══════════════════════════════════════════════════════════════

Running: Pure Macro Transform...

  Pure Macro Transform (no I/O, no catalogs):
    Babel             █████████████████████████  1.54s  650 files/s ±9.8%
    SWC               ███████████░░░░░░░░░░░░░░  668ms  1497 files/s
    SWC - customized  ██░░░░░░░░░░░░░░░░░░░░░░░  140ms  7162 files/s ±5.4% ⚡

  Summary:
    SWC - customized is 11.0x faster than Babel
    SWC - customized is 4.8x faster than SWC

```

Result: 718ms → 148ms (4.9x faster, 1000 files / 10K messages)

  1. Eliminated regex crate entirely (biggest win — ~4x)

  The regex crate is extremely expensive in WASM. Replaced all regex usage with hand-written string operations:

  - jsx_visitor.rs: Replaced clean_jsx_element_literal_child (which allocated 2 regexes on every call!) with split_lines() + trim_start_matches/trim_end_matches. Replaced PLURAL_OPTIONS_WHITELIST, NUM_OPTION, WORD_OPTION regexes with a simple match + byte checks.
  - builder.rs: Replaced NUMERIC_REGEX and VALID_NAME_REGEX with is_numeric() and is_valid_placeholder_name() functions.
  - comment_directive/mod.rs: Replaced DIRECTIVE_RE and TOKEN_RE with a hand-written parser.
  
2. Optimized generate_message_id

  Replaced format!("{message}{UNIT_SEPARATOR}{context}") allocation with direct hasher.update() calls on the byte slices.

  3. Changed opt-level from "s" to 3

  Binary went from ~2.5MB (with regex + opt-level s) to 1.9MB (no regex + opt-level 3) — both smaller AND faster.
