### PR TITLE
fix: make runtime_modules optional

### DIFF
--- a/crates/lingui_macro/src/options.rs
+++ b/crates/lingui_macro/src/options.rs
@@ -32,6 +32,7 @@ impl DescriptorFields {
 #[derive(Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LinguiJsOptions {
+    #[serde(default)]
     runtime_modules: Option<RuntimeModulesConfigMap>,
     #[serde(default)]
     core_package: Option<Vec<String>>,
@@ -311,12 +312,7 @@ mod lib_tests {
 
     #[test]
     fn test_macro_package_defaults() {
-        let config = serde_json::from_str::<LinguiJsOptions>(
-            r#"{
-                "runtimeModules": {}
-               }"#,
-        )
-        .unwrap();
+        let config = serde_json::from_str::<LinguiJsOptions>(r#"{}"#).unwrap();
 
         let options = config.into_options("development");
         assert_eq!(
@@ -339,8 +335,7 @@ mod lib_tests {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
                 "corePackage": ["@acme/core/macro"],
-                "jsxPackage": ["@acme/react/macro"],
-                "runtimeModules": {}
+                "jsxPackage": ["@acme/react/macro"]
                }"#,
         )
         .unwrap();
@@ -363,8 +358,7 @@ mod lib_tests {
     fn test_id_prefix_leader_config() {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "idPrefixLeader": ".",
-                "runtimeModules": {}
+                "idPrefixLeader": "."
                }"#,
         )
         .unwrap();
@@ -377,8 +371,7 @@ mod lib_tests {
     fn test_descriptor_fields_config() {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "descriptorFields": "id-only",
-                "runtimeModules": {}
+                "descriptorFields": "id-only"
                }"#,
         )
         .unwrap();
@@ -391,8 +384,7 @@ mod lib_tests {
 
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "descriptorFields": "all",
-                "runtimeModules": {}
+                "descriptorFields": "all"
                }"#,
         )
         .unwrap();
@@ -402,8 +394,7 @@ mod lib_tests {
 
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "descriptorFields": "message",
-                "runtimeModules": {}
+                "descriptorFields": "message"
                }"#,
         )
         .unwrap();
@@ -417,22 +408,12 @@ mod lib_tests {
 
     #[test]
     fn test_descriptor_fields_auto_default() {
-        let config = serde_json::from_str::<LinguiJsOptions>(
-            r#"{
-                "runtimeModules": {}
-               }"#,
-        )
-        .unwrap();
+        let config = serde_json::from_str::<LinguiJsOptions>(r#"{}"#).unwrap();
 
         let options = config.into_options("development");
         assert!(matches!(options.descriptor_fields, DescriptorFields::All));
 
-        let config = serde_json::from_str::<LinguiJsOptions>(
-            r#"{
-                "runtimeModules": {}
-               }"#,
-        )
-        .unwrap();
+        let config = serde_json::from_str::<LinguiJsOptions>(r#"{}"#).unwrap();
 
         let options = config.into_options("production");
         assert!(matches!(
@@ -466,8 +447,7 @@ mod lib_tests {
     fn test_descriptor_fields_explicit_auto() {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "descriptorFields": "auto",
-                "runtimeModules": {}
+                "descriptorFields": "auto"
                }"#,
         )
         .unwrap();
@@ -477,8 +457,7 @@ mod lib_tests {
 
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "descriptorFields": "auto",
-                "runtimeModules": {}
+                "descriptorFields": "auto"
                }"#,
         )
         .unwrap();
@@ -494,8 +473,7 @@ mod lib_tests {
     fn test_use_lingui_v5_id_generation_config() {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "useLinguiV5IdGeneration": true,
-                "runtimeModules": {}
+                "useLinguiV5IdGeneration": true
                }"#,
         )
         .unwrap();
@@ -505,8 +483,7 @@ mod lib_tests {
 
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "useLinguiV5IdGeneration": false,
-                "runtimeModules": {}
+                "useLinguiV5IdGeneration": false
                }"#,
         )
         .unwrap();
@@ -517,6 +494,31 @@ mod lib_tests {
 
     #[test]
     fn test_use_lingui_v5_id_generation_default() {
+        let config = serde_json::from_str::<LinguiJsOptions>(r#"{}"#).unwrap();
+
+        let options = config.into_options("development");
+        assert!(!options.use_lingui_v5_id_generation);
+
+        let config = serde_json::from_str::<LinguiJsOptions>(r#"{}"#).unwrap();
+
+        let options = config.into_options("production");
+        assert!(!options.use_lingui_v5_id_generation);
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let config = serde_json::from_str::<LinguiJsOptions>(r#"{}"#).unwrap();
+
+        let options = config.into_options("development");
+        assert_eq!(
+            options.runtime_modules,
+            RuntimeModulesConfigMapNormalized::default()
+        );
+        assert_eq!(options.macro_packages, MacroPackagesConfig::default());
+    }
+
+    #[test]
+    fn test_runtime_modules_fully_optional() {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
                 "runtimeModules": {}
@@ -525,16 +527,35 @@ mod lib_tests {
         .unwrap();
 
         let options = config.into_options("development");
-        assert!(!options.use_lingui_v5_id_generation);
+        assert_eq!(
+            options.runtime_modules,
+            RuntimeModulesConfigMapNormalized::default()
+        );
+    }
 
+    #[test]
+    fn test_runtime_modules_partial() {
         let config = serde_json::from_str::<LinguiJsOptions>(
             r#"{
-                "runtimeModules": {}
+                "runtimeModules": {
+                    "i18n": ["my-core", "myI18n"]
+                }
                }"#,
         )
         .unwrap();
 
-        let options = config.into_options("production");
-        assert!(!options.use_lingui_v5_id_generation);
+        let options = config.into_options("development");
+        assert_eq!(
+            options.runtime_modules.i18n,
+            ("my-core".into(), "myI18n".into())
+        );
+        assert_eq!(
+            options.runtime_modules.trans,
+            ("@lingui/react".into(), "Trans".into())
+        );
+        assert_eq!(
+            options.runtime_modules.use_lingui,
+            ("@lingui/react".into(), "useLingui".into())
+        );
     }
 }

--- a/packages/lingui-macro/src-js/map-options.ts
+++ b/packages/lingui-macro/src-js/map-options.ts
@@ -13,10 +13,10 @@ export type LinguiMacroOptions = {
   /** Default placeholder names for JSX tags when no explicit placeholder attribute is present. */
   jsxPlaceholderDefaults?: Record<string, string>
   /** Overrides the runtime imports used by the plugin. Unlike the Babel macro configuration, must be passed as an object. */
-  runtimeModules: {
-    i18n: RuntimeModuleConfig
-    Trans: RuntimeModuleConfig
-    useLingui: RuntimeModuleConfig
+  runtimeModules?: {
+    i18n?: RuntimeModuleConfig
+    Trans?: RuntimeModuleConfig
+    useLingui?: RuntimeModuleConfig
   }
   /**
    * Compatibility option for using the v6 SWC plugin with `@lingui/cli@5.*`.


### PR DESCRIPTION
i noticed that `runtimeModules` options was required for some reason. I updated typings and rust implementation so now it's optional