### PR TITLE
feat(options): make options serializable + re-generate snapshots

### DIFF
--- a/crates/lingui_macro/src/options.rs
+++ b/crates/lingui_macro/src/options.rs
@@ -29,37 +29,37 @@ impl DescriptorFields {
     }
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct LinguiJsOptions {
     #[serde(default)]
-    runtime_modules: Option<RuntimeModulesConfigMap>,
+    pub runtime_modules: Option<RuntimeModulesConfigMap>,
     #[serde(default)]
-    core_package: Option<Vec<String>>,
+    pub core_package: Option<Vec<String>>,
     #[serde(default)]
-    jsx_package: Option<Vec<String>>,
+    pub jsx_package: Option<Vec<String>>,
     #[serde(default)]
-    descriptor_fields: Option<DescriptorFields>,
+    pub descriptor_fields: Option<DescriptorFields>,
     #[serde(default)]
-    use_lingui_v5_id_generation: Option<bool>,
+    pub use_lingui_v5_id_generation: Option<bool>,
     #[serde(default)]
-    id_prefix_leader: Option<String>,
+    pub id_prefix_leader: Option<String>,
     #[serde(default)]
-    jsx_placeholder_attribute: Option<String>,
+    pub jsx_placeholder_attribute: Option<String>,
     #[serde(default)]
-    jsx_placeholder_defaults: Option<HashMap<String, String>>,
+    pub jsx_placeholder_defaults: Option<HashMap<String, String>>,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
-struct RuntimeModulesConfig(String, #[serde(default)] Option<String>);
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Default)]
+pub struct RuntimeModulesConfig(pub String, #[serde(default)] pub Option<String>);
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeModulesConfigMap {
-    i18n: Option<RuntimeModulesConfig>,
+    pub i18n: Option<RuntimeModulesConfig>,
     #[serde(alias = "Trans")]
-    trans: Option<RuntimeModulesConfig>,
-    use_lingui: Option<RuntimeModulesConfig>,
+    pub trans: Option<RuntimeModulesConfig>,
+    pub use_lingui: Option<RuntimeModulesConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/crates/lingui_macro/tests/snapshots/imports__js_should_process_only_elements_imported_from_macro.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__js_should_process_only_elements_imported_from_macro.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { plural } from "@lingui/core/macro";
 import { t } from "./custom-t";

--- a/crates/lingui_macro/tests/snapshots/imports__js_should_process_only_elements_imported_from_macro2.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__js_should_process_only_elements_imported_from_macro2.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { t } from "@lingui/core/macro";
 import { plural } from "./custom-plural";

--- a/crates/lingui_macro/tests/snapshots/imports__js_should_support_renamed_imports.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__js_should_support_renamed_imports.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { t as i18nT, plural as i18nPlural } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/imports__jsx_should_process_only_elements_imported_from_macro.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__jsx_should_process_only_elements_imported_from_macro.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { Plural } from "@lingui/react/macro";
 import { Select } from "./my-select-cmp";

--- a/crates/lingui_macro/tests/snapshots/imports__jsx_should_process_only_elements_imported_from_macro2.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__jsx_should_process_only_elements_imported_from_macro2.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { Trans } from "@lingui/react";
 import { Plural } from "@lingui/react/macro";

--- a/crates/lingui_macro/tests/snapshots/imports__jsx_should_support_renamed_imports.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__jsx_should_support_renamed_imports.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { Trans as I18nTrans, Plural as I18nPlural } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/imports__should_add_imports_after_directive_prologues.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__should_add_imports_after_directive_prologues.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 "use client";
  import { t } from "@lingui/core/macro"

--- a/crates/lingui_macro/tests/snapshots/imports__should_add_not_clashing_imports.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__should_add_not_clashing_imports.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { t } from "@lingui/core/macro";
 import { Plural } from "@lingui/react/macro";

--- a/crates/lingui_macro/tests/snapshots/imports__should_transform_custom_core_macro_package.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__should_transform_custom_core_macro_package.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 info:
   macro_packages:
     core:

--- a/crates/lingui_macro/tests/snapshots/imports__should_transform_custom_jsx_macro_package.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__should_transform_custom_jsx_macro_package.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/imports.rs
+source: crates/lingui_macro/tests/imports.rs
 info:
   macro_packages:
     core:

--- a/crates/lingui_macro/tests/snapshots/imports__should_transform_messages_after_ts_module_declarations.snap
+++ b/crates/lingui_macro/tests/snapshots/imports__should_transform_messages_after_ts_module_declarations.snap
@@ -1,6 +1,5 @@
 ---
-source: tests/imports.rs
-assertion_line: 139
+source: crates/lingui_macro/tests/imports.rs
 ---
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";

--- a/crates/lingui_macro/tests/snapshots/js_define_message__define_message_should_support_template_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__define_message_should_support_template_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 ---
 import { defineMessage, msg } from '@lingui/macro';
 const message1 = defineMessage`Message`;

--- a/crates/lingui_macro/tests/snapshots/js_define_message__id_only_should_keep_only_id.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__id_only_should_keep_only_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 info:
   descriptor_fields: id-only
 ---

--- a/crates/lingui_macro/tests/snapshots/js_define_message__message_should_keep_message_and_context.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__message_should_keep_message_and_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 info:
   descriptor_fields: message
 ---

--- a/crates/lingui_macro/tests/snapshots/js_define_message__should_expand_macros.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__should_expand_macros.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 ---
 import { defineMessage, plural, arg } from '@lingui/macro';
 const message = defineMessage({

--- a/crates/lingui_macro/tests/snapshots/js_define_message__should_expand_values.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__should_expand_values.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 ---
 import { defineMessage, plural, arg } from '@lingui/macro';
 const message = defineMessage({

--- a/crates/lingui_macro/tests/snapshots/js_define_message__should_preserve_custom_id.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__should_preserve_custom_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 ---
 import { defineMessage, plural, arg } from '@lingui/macro';
 const message = defineMessage({

--- a/crates/lingui_macro/tests/snapshots/js_define_message__should_transform_define_message.snap
+++ b/crates/lingui_macro/tests/snapshots/js_define_message__should_transform_define_message.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_define_message.rs
+source: crates/lingui_macro/tests/js_define_message.rs
 ---
 import { defineMessage, msg } from '@lingui/macro';
 const message1 = defineMessage({

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_choices_may_contain_expressions.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_choices_may_contain_expressions.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural, select, selectOrdinal } from "@lingui/core/macro";
 const messagePlural = plural(count, {

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_dedup_values_in_icu.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_dedup_values_in_icu.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_icu_diffrent_object_literal_syntax.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_icu_diffrent_object_literal_syntax.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_icu_macro.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_icu_macro.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural, select, selectOrdinal } from "@lingui/core/macro";
 const messagePlural = plural(count, {

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_icu_nested_in_choices.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_icu_nested_in_choices.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural } from "@lingui/core/macro"
 const message = plural(numBooks, {

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_icu_nested_in_t.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_icu_nested_in_t.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { t, selectOrdinal } from '@lingui/macro'
 

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_plural_with_offset_and_exact_matches.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_plural_with_offset_and_exact_matches.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural } from '@lingui/macro'
 plural(users.length, {

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_plural_with_placeholders.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_plural_with_placeholders.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_should_not_touch_non_lungui_fns.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_should_not_touch_non_lungui_fns.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { plural } from "@lingui/core/macro";
 const messagePlural = customName(count, {

--- a/crates/lingui_macro/tests/snapshots/js_icu__js_should_not_treat_offset_in_select.snap
+++ b/crates/lingui_macro/tests/snapshots/js_icu__js_should_not_treat_offset_in_select.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_icu.rs
+source: crates/lingui_macro/tests/js_icu.rs
 ---
 import { select } from '@lingui/macro'
 select(value, {

--- a/crates/lingui_macro/tests/snapshots/js_t__js_choice_labels_in_tpl_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_choice_labels_in_tpl_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t, ph, plural, select, selectOrdinal } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_continuation_character.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_continuation_character.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro';
   t`Multiline\

--- a/crates/lingui_macro/tests/snapshots/js_t__js_custom_i18n_passed.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_custom_i18n_passed.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from "@lingui/core/macro";
 import { custom_i18n } from "./i18n";

--- a/crates/lingui_macro/tests/snapshots/js_t__js_dedup_values_in_tpl_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_dedup_values_in_tpl_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from "@lingui/core/macro";
 t`Refresh ${foo} inbox ${foo}`

--- a/crates/lingui_macro/tests/snapshots/js_t__js_explicit_labels_in_tpl_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_explicit_labels_in_tpl_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_id_only_should_keep_only_id.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_id_only_should_keep_only_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 info:
   descriptor_fields: id-only
 ---

--- a/crates/lingui_macro/tests/snapshots/js_t__js_message_should_keep_message_and_context.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_message_should_keep_message_and_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 info:
   descriptor_fields: message
 ---

--- a/crates/lingui_macro/tests/snapshots/js_t__js_newlines_are_preserved.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_newlines_are_preserved.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro';
   t`Multiline

--- a/crates/lingui_macro/tests/snapshots/js_t__js_ph_labels_in_tpl_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_ph_labels_in_tpl_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t, ph } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_should_not_touch_code_if_no_macro_import.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_should_not_touch_code_if_no_macro_import.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 t`Refresh inbox`;
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_should_not_touch_not_related_tagget_tpls.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_should_not_touch_not_related_tagget_tpls.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_should_produce_all_fields_when_no_message_set.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_should_produce_all_fields_when_no_message_set.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 const msg2 = t({

--- a/crates/lingui_macro/tests/snapshots/js_t__js_should_produce_all_fields_without_strip_flag.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_should_produce_all_fields_without_strip_flag.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 const msg2 = t({

--- a/crates/lingui_macro/tests/snapshots/js_t__js_should_use_v5_generate_id_with_parameter.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_should_use_v5_generate_id_with_parameter.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 info:
   use_lingui_v5_id_generation: true
 ---

--- a/crates/lingui_macro/tests/snapshots/js_t__js_should_work_with_legacy_import.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_should_work_with_legacy_import.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
  import { t } from "@lingui/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_substitution_in_tpl_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_substitution_in_tpl_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from "@lingui/core/macro";
 

--- a/crates/lingui_macro/tests/snapshots/js_t__js_support_message_descriptor_in_t_fn.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_support_message_descriptor_in_t_fn.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 const msg = t({ message: `Hello ${name}`, id: 'msgId', comment: 'description for translators'  })

--- a/crates/lingui_macro/tests/snapshots/js_t__js_support_template_strings_in_t_macro_message_with_custom_i18n_instance.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_support_template_strings_in_t_macro_message_with_custom_i18n_instance.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 import { i18n_custom } from './lingui'

--- a/crates/lingui_macro/tests/snapshots/js_t__js_t_fn_wrapped_in_call_expr.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_t_fn_wrapped_in_call_expr.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 const msg = message.error(t({message: "dasd"}))

--- a/crates/lingui_macro/tests/snapshots/js_t__should_generate_diffrent_id_when_context_provided.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__should_generate_diffrent_id_when_context_provided.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 t({ message: 'Ola' })

--- a/crates/lingui_macro/tests/snapshots/js_t__support_id_and_comment_in_t_macro_as_call_expression.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__support_id_and_comment_in_t_macro_as_call_expression.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t, plural } from '@lingui/core/macro'
 const msg = t({ id: 'msgId', comment: 'description for translators', message: plural(val, { one: '...', other: '...' }) })

--- a/crates/lingui_macro/tests/snapshots/js_t__support_id_in_template_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__support_id_in_template_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro'
 const msg = t({ id: `msgId` })

--- a/crates/lingui_macro/tests/snapshots/js_t__unicode_characters_interpreted.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__unicode_characters_interpreted.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/js_t.rs
+source: crates/lingui_macro/tests/js_t.rs
 ---
 import { t } from '@lingui/core/macro';
 t`Message \u0020`;

--- a/crates/lingui_macro/tests/snapshots/jsx__elements_inside_expression_container.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__elements_inside_expression_container.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>{<span>Component inside expression container</span>}</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__elements_without_children.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__elements_without_children.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>{<br />}</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__html_attributes_are_handled.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__html_attributes_are_handled.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__id_only_essential_props_are_kept.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__id_only_essential_props_are_kept.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 info:
   descriptor_fields: id-only
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx__ignore_jsx_empty_expression.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__ignore_jsx_empty_expression.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>Hello {/* and I cannot stress this enough */} World</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_comments_should_not_affect_expression_index.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_comments_should_not_affect_expression_index.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from '@lingui/react/macro';
 // Without comment - expression gets index 0

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_components_interpolation.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_components_interpolation.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_explicit_labels.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_explicit_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_explicit_labels_with_as_statement.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_explicit_labels_with_as_statement.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>Refresh {{foo} as unknown as string} inbox</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_expressions_are_converted_to_positional_arguments.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_expressions_are_converted_to_positional_arguments.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_nested_labels.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_nested_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans, ph } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_ph_labels.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_ph_labels.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans, ph } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_preserve_reserved_attrs.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_preserve_reserved_attrs.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 const exp2 = <Trans comment="Translators Comment" context="Message Context" i18n="i18n" component={(p) => <div>{p.translation}</div>} render={(v) => v}>Refresh inbox</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_should_suppor_legacy_import.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_should_suppor_legacy_import.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/macro";
 const exp2 = <Trans>Refresh inbox</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_simple_jsx.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_simple_jsx.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 const exp1 = <Custom>Refresh inbox</Custom>;

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_template_literal_in_children.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_template_literal_in_children.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>{`Hello ${foo} and ${bar}`}</Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_values_dedup.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_values_dedup.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_with_context.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_with_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 const exp1 = <Trans>Refresh inbox</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_with_custom_id.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_with_custom_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 const exp2 = <Trans id="custom.id">Refresh inbox</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__keep_multiple_forced_newlines.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__keep_multiple_forced_newlines.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__message_keeps_message_and_context.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__message_keeps_message_and_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 info:
   descriptor_fields: message
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx__non_breaking_whitespace_handling_2226.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__non_breaking_whitespace_handling_2226.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__quoted_jsx_attributes_are_handled.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__quoted_jsx_attributes_are_handled.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>Speak "friend"!</Trans>;

--- a/crates/lingui_macro/tests/snapshots/jsx__strip_whitespace_around_arguments.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__strip_whitespace_around_arguments.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__strip_whitespace_around_tags_but_keep_forced_spaces.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__strip_whitespace_around_tags_but_keep_forced_spaces.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__strip_whitespaces_in_jsxtext_but_keep_in_jsx_expression_containers.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__strip_whitespaces_in_jsxtext_but_keep_in_jsx_expression_containers.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
   <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__use_decoded_html_entities.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__use_decoded_html_entities.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>&amp;</Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx__use_js_macro_in_jsx_attrs.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__use_js_macro_in_jsx_attrs.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';

--- a/crates/lingui_macro/tests/snapshots/jsx__use_js_plural_in_jsx_attrs.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__use_js_plural_in_jsx_attrs.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx.rs
+source: crates/lingui_macro/tests/jsx.rs
 ---
 import { plural } from '@lingui/core/macro';
 <a href="/about" title={plural(count, {

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__id_only_essential_props_are_kept.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__id_only_essential_props_are_kept.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 info:
   descriptor_fields: id-only
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Plural } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
  import { Plural } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_nested.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_nested.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
  import { Plural, Trans } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_with_template_literal.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_with_template_literal.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Plural } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_multivelel_nesting.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_multivelel_nesting.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Trans, Plural } from '@lingui/macro';
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_plural_preserve_reserved_attrs.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_plural_preserve_reserved_attrs.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
  import { Plural } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_plural_with_offset_and_exact_matches.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_plural_with_offset_and_exact_matches.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Plural } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_ordinal_with_offset_and_exact_matches.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_ordinal_with_offset_and_exact_matches.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { SelectOrdinal } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_simple.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_simple.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Select } from '@lingui/macro';
 <Select

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_with_expressions_in_cases.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_with_expressions_in_cases.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Select } from '@lingui/macro';
 <Select

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_with_reserved_attrs.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_select_with_reserved_attrs.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Select } from '@lingui/macro';
 <Select

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_trans_inside_plural.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_trans_inside_plural.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Trans, Plural } from '@lingui/macro';
  <Plural

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__message_keeps_message_and_context.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__message_keeps_message_and_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 info:
   descriptor_fields: message
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__multiple_new_lines_with_nbsp_endind.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__multiple_new_lines_with_nbsp_endind.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_icu.rs
+source: crates/lingui_macro/tests/jsx_icu.rs
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__allows_dotted.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__allows_dotted.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__allows_hyphenated.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__allows_hyphenated.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__attribute_ignored_when_not_configured.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__attribute_ignored_when_not_configured.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info: {}
 ---
 import { Trans } from "@lingui/react/macro";

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__basic.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__basic.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__deduplication_different_props.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__deduplication_different_props.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_defaults:
     a: a

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__deduplication_identical.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__deduplication_identical.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_defaults:
     em: em

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__deduplication_with_stripped_props.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__deduplication_with_stripped_props.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__defaults.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__defaults.snap
@@ -1,9 +1,9 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_defaults:
-    a: link
     em: em
+    a: link
 ---
 import { Trans } from "@lingui/react/macro";
 <Trans>

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__different_spreads_throw.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__different_spreads_throw.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__identical_spreads_reused.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__identical_spreads_reused.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__mixed_explicit_and_defaults.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__mixed_explicit_and_defaults.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
   jsx_placeholder_defaults:

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__prop_order.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__prop_order.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__prop_order2.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__prop_order2.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__same_element_different_attributes_count_throws.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__same_element_different_attributes_count_throws.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__same_name_different_element_throws.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__same_name_different_element_throws.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__same_spread_different_order_throws.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__same_spread_different_order_throws.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__stripped_ast.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__stripped_ast.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__supports_string_in_jsx_expression.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__supports_string_in_jsx_expression.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_ending_with_dot.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_ending_with_dot.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_boolean_expr.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_boolean_expr.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_empty_attribute_value.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_empty_attribute_value.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_non_string_attribute_value.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_non_string_attribute_value.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_numeric_name.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_on_numeric_name.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_starting_with_hyphen.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_named_placeholders__throws_starting_with_hyphen.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/jsx_named_placeholders.rs
+source: crates/lingui_macro/tests/jsx_named_placeholders.rs
 info:
   jsx_placeholder_attribute: _t
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_explicit_context_overrides_directive.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_explicit_context_overrides_directive.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { defineMessage } from '@lingui/core/macro';
 /* lingui-set context="directive ctx" comment="directive cmt" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_id_prefix_leader_with_matching_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_id_prefix_leader_with_matching_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_id_prefix_leader_with_non_matching_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_id_prefix_leader_with_non_matching_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_id_prefix_with_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_id_prefix_with_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { defineMessage } from '@lingui/core/macro';
 /* lingui-set idPrefix="module." */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_tagged_template_with_directive.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_tagged_template_with_directive.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { defineMessage } from '@lingui/core/macro';
 /* lingui-set context="my context" comment="note" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__define_message_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { defineMessage } from '@lingui/core/macro';
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_plural_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_plural_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { plural } from "@lingui/core/macro";
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_select_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_select_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { select } from "@lingui/core/macro";
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_closest_directive_takes_precedence.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_closest_directive_takes_precedence.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="first" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_directive_applies_to_multiple_subsequent_macros.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_directive_applies_to_multiple_subsequent_macros.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="shared" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_directives_merge_with_preceding_ones.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_directives_merge_with_preceding_ones.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="ctx" comment="cmt" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_empty_param_value_clears_single_param.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_empty_param_value_clears_single_param.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="first" comment="second" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_explicit_comment_overrides_directive.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_explicit_comment_overrides_directive.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set comment="directive cmt" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_id_only_with_directive_context_uses_context_for_hash.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_id_only_with_directive_context_uses_context_for_hash.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   descriptor_fields: id-only
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_id_prefix_leader_with_dynamic_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_id_prefix_leader_with_dynamic_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_id_prefix_with_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_id_prefix_with_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set idPrefix="module." */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_reset_clears_all_inherited_values.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_reset_clears_all_inherited_values.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="first" comment="second" idPrefix="prefix." */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_reset_combined_with_new_values.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_reset_combined_with_new_values.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="first" comment="second" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_before_removed_macro_import_after_regular_import.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import foo from 'bar';
 /* lingui-set context="test" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_comment_line_comment.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_comment_line_comment.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 // lingui-set comment="translator note"

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_context_and_comment.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_context_and_comment.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="ctx" comment="cmt" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_context_block_comment.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_directive_context_block_comment.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { t } from '@lingui/core/macro';
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_id_prefix_leader.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_id_prefix_leader.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_top_of_file_directive_before_macro_import.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__js_t_with_top_of_file_directive_before_macro_import.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 // lingui-set context="test"
 import { t } from '@lingui/core/macro';

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_multiple_directives_switching_context_mid_file.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_multiple_directives_switching_context_mid_file.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 /* lingui-set context="header" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_plural_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_plural_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Plural } from "@lingui/react/macro";
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_select_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_select_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Select } from "@lingui/react/macro";
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_comment.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_comment.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 // lingui-set comment="translator note"

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 /* lingui-set context="my context" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_id_prefix_and_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_id_prefix_and_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 /* lingui-set idPrefix="module." */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_id_prefix_without_explicit_id.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_directive_id_prefix_without_explicit_id.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 /* lingui-set idPrefix="module." */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_dynamic_id_and_id_prefix.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_dynamic_id_and_id_prefix.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 /* lingui-set idPrefix="module." */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_dynamic_id_and_no_id_prefix.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_dynamic_id_and_no_id_prefix.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 const dynId = "dynamic";

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_explicit_context_overrides_directive.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_explicit_context_overrides_directive.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { Trans } from "@lingui/react/macro";
 /* lingui-set context="directive ctx" */

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_id_prefix_leader.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_id_prefix_leader.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_matching_id_prefix_leader.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_matching_id_prefix_leader.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_non_matching_id_prefix_leader.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__jsx_trans_with_non_matching_id_prefix_leader.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 info:
   id_prefix_leader: "."
 ---

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__use_lingui_t_with_directive_applied_per_reference.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__use_lingui_t_with_directive_applied_per_reference.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/lingui_directive__use_lingui_t_with_directive_context.snap
+++ b/crates/lingui_macro/tests/snapshots/lingui_directive__use_lingui_t_with_directive_context.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/lingui_directive.rs
+source: crates/lingui_macro/tests/lingui_directive.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/runtime_config__should_use_provided_runtime_modules.snap
+++ b/crates/lingui_macro/tests/snapshots/runtime_config__should_use_provided_runtime_modules.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/runtime_config.rs
+source: crates/lingui_macro/tests/runtime_config.rs
 info:
   runtime_modules:
     i18n:

--- a/crates/lingui_macro/tests/snapshots/use_lingui__js_use_lingui_hook.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__js_use_lingui_hook.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from "@lingui/react/macro";
 

--- a/crates/lingui_macro/tests/snapshots/use_lingui__should_process_macro_with_matching_name_in_correct_scopes.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__should_process_macro_with_matching_name_in_correct_scopes.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/use_lingui__support_nested_macro.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__support_nested_macro.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 import { plural } from '@lingui/core/macro';

--- a/crates/lingui_macro/tests/snapshots/use_lingui__support_nested_macro_when_in_arrow_function_issue_2095.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__support_nested_macro_when_in_arrow_function_issue_2095.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { plural } from '@lingui/core/macro'
 import { useLingui } from '@lingui/react/macro'

--- a/crates/lingui_macro/tests/snapshots/use_lingui__support_passing_t_variable_as_dependency.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__support_passing_t_variable_as_dependency.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/use_lingui__support_renamed_destructuring.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__support_renamed_destructuring.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/use_lingui__work_when_t_is_not_used.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__work_when_t_is_not_used.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/use_lingui__work_with_components_defined_as_arrow_function.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__work_with_components_defined_as_arrow_function.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 

--- a/crates/lingui_macro/tests/snapshots/use_lingui__work_with_existing_use_lingui_statement.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__work_with_existing_use_lingui_statement.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui as useLinguiMacro } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';

--- a/crates/lingui_macro/tests/snapshots/use_lingui__work_with_multiple_react_components.snap
+++ b/crates/lingui_macro/tests/snapshots/use_lingui__work_with_multiple_react_components.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/use_lingui.rs
+source: crates/lingui_macro/tests/use_lingui.rs
 ---
 import { useLingui } from '@lingui/react/macro';
 


### PR DESCRIPTION
Continue preparing a repo for merge with SWC extractor, this PR adds seralization for macro options which is later used in swc extractor tests. (i'd like to completely eleminate any diff between two branched related to the macro itself)


+ regenerate snapshots, so it would not trigger diffs in untrelated PRs such as here https://github.com/lingui/swc-plugin/pull/232