### PR TITLE
fix: JS imports to be compatible with ESM

### DIFF
--- a/packages/lingui-macro/src-js/options.ts
+++ b/packages/lingui-macro/src-js/options.ts
@@ -1,8 +1,8 @@
 import {getConfig} from "@lingui/conf"
-import {mapOptions, DeepPartial, LinguiMacroOptions} from "./map-options"
+import {mapOptions, DeepPartial, LinguiMacroOptions} from "./map-options.js"
 
-export type {RuntimeModuleConfig, LinguiMacroOptions} from "./map-options"
-export {mapOptions} from "./map-options"
+export type {RuntimeModuleConfig, LinguiMacroOptions} from "./map-options.js"
+export {mapOptions} from "./map-options.js"
 
 /** Controls how the Lingui config is located and loaded. */
 export type GetConfigOptions = {


### PR DESCRIPTION
When trying to import linguiMacroSwcPlugin from a project using ESM we get this error:

```
> lingui-swc-plugin-bug-esm@1.0.0 start
> node index.js

node:internal/modules/esm/resolve:265
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/me/dev/lingui-swc-plugin-bug-esm/node_modules/@lingui/swc-plugin/dist/map-options' imported from /Users/me/dev/lingui-swc-plugin-bug-esm/node_modules/@lingui/swc-plugin/dist/options.js
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:227:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
    at link (node:internal/modules/esm/module_job:86:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/me/dev/lingui-swc-plugin-bug-esm/node_modules/@lingui/swc-plugin/dist/map-options'
}
```

This PR fixes JS imports to be compatible with ESM by adding the filename extensions to the imports

Standalone reproduction of problem:

https://github.com/DanielHoffmann/lingui-swc-plugin-bug-esm


I ran `cd packages/lingui-macro && yarn build:ts` and `cd packages/lingui-macro && yarn test:e2e` and both passed