### PR TITLE
fix: align numeric placeholder generation with babel

### DIFF
--- a/crates/lingui_macro/src/builder.rs
+++ b/crates/lingui_macro/src/builder.rs
@@ -92,6 +92,8 @@ pub struct MessageBuilder<'a> {
     options: &'a LinguiOptions,
     elements_tracking: Vec<(String, JSXOpeningElement)>,
     element_index: usize,
+    // Counter for auto-generated numeric placeholders
+    numeric_index: usize,
 }
 
 impl<'a> MessageBuilder<'a> {
@@ -105,6 +107,7 @@ impl<'a> MessageBuilder<'a> {
             options,
             elements_tracking: Vec::new(),
             element_index: 0,
+            numeric_index: 0,
         };
 
         builder.process_tokens(tokens);
@@ -292,6 +295,12 @@ impl<'a> MessageBuilder<'a> {
         }
     }
 
+    fn next_numeric_index(&mut self) -> String {
+        let index = self.numeric_index.to_string();
+        self.numeric_index += 1;
+        index
+    }
+
     fn push_exp(&mut self, mut exp: Box<Expr>) -> String {
         exp = expand_ts_as_expr(exp);
 
@@ -334,7 +343,7 @@ impl<'a> MessageBuilder<'a> {
                 }
 
                 // fallback for {...spread} or {}
-                let index = self.values_indexed.len().to_string();
+                let index = self.next_numeric_index();
 
                 self.values_indexed.push(ValueWithPlaceholder {
                     placeholder: index.clone(),
@@ -344,7 +353,7 @@ impl<'a> MessageBuilder<'a> {
                 index
             }
             _ => {
-                let index = self.values_indexed.len().to_string();
+                let index = self.next_numeric_index();
 
                 self.values_indexed.push(ValueWithPlaceholder {
                     placeholder: index.clone(),

--- a/crates/lingui_macro/tests/jsx.rs
+++ b/crates/lingui_macro/tests/jsx.rs
@@ -145,6 +145,18 @@ to!(
 );
 
 to!(
+    jsx_ph_label_with_nested_plural,
+    r##"
+       import { Trans, Plural, ph } from "@lingui/react/macro";
+
+       const zones = [1, 2]
+       const x = <Trans id="key">
+         {ph({ available: 1 })} of <Plural value={zones.length} one="# zone" other="# zones" /> available
+       </Trans>
+     "##
+);
+
+to!(
     jsx_nested_labels,
     r#"
        import { Trans, ph } from "@lingui/react/macro";

--- a/crates/lingui_macro/tests/snapshots/jsx__jsx_ph_label_with_nested_plural.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx__jsx_ph_label_with_nested_plural.snap
@@ -1,0 +1,25 @@
+---
+source: crates/lingui_macro/tests/jsx.rs
+---
+import { Trans, Plural, ph } from "@lingui/react/macro";
+
+const zones = [1, 2]
+const x = <Trans id="key">
+  {ph({ available: 1 })} of <Plural value={zones.length} one="# zone" other="# zones" /> available
+</Trans>
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as Trans_ } from "@lingui/react";
+const zones = [
+    1,
+    2
+];
+const x = <Trans_ {.../*i18n*/ {
+    id: "key",
+    values: {
+        available: 1,
+        0: zones.length
+    },
+    message: "{available} of {0, plural, one {# zone} other {# zones}} available"
+}}/>;


### PR DESCRIPTION
The SWC plugin assigned auto-generated numeric placeholder indices (`{0}`, `{1}`, …) differently from the reference Babel/JS macro (`@lingui/babel-plugin-lingui-macro`).  Because message IDs and `values` keys are derived from these indices, the two toolchains could extract different catalogs for identical source, and thus break translation lookups in projects that mix the JS and SWC tooling.

`ph({ name })`, `{label: value}` and bare identifiers carry an explicit name and, in the babel macro, never advance the counter. The SWC plugin derived the next numeric index from `values_indexed.len()`, which also counted named placeholders, so any unnamed expression following a named one was numbered one too high.

```tsx
<Trans>
  {ph({ available: 1 })} of <Plural value={zones.length} one="# zone" other="# zones" /> available
</Trans>
```

| | message |
|---|---|
| Before | `{available} of {1, plural, one {# zone} other {# zones}} available` |
| After / in JS | `{available} of {0, plural, one {# zone} other {# zones}} available` |

### Fix

Replaced the `values_indexed.len()`-based index with a dedicated `numeric_index` counter (`next_numeric_index`) that is advanced only when an auto-numeric placeholder is actually assigned — never for named placeholders. This mirrors `getExpressionIndex`.