### PR TITLE
fix: align numeric placeholder generation in `<Plural>` with babel

### DIFF
--- a/crates/lingui_macro/src/builder.rs
+++ b/crates/lingui_macro/src/builder.rs
@@ -357,26 +357,51 @@ impl<'a> MessageBuilder<'a> {
     }
 
     fn push_icu(&mut self, icu: IcuChoice) {
-        let value_placeholder = self.push_exp(icu.value);
-        let method = icu.format;
-        self.push_msg(&format!("{{{value_placeholder}, {method},"));
+        let IcuChoice {
+            value,
+            format: method,
+            cases,
+            value_pos,
+        } = icu;
 
-        for choice in icu.cases {
+        // The value placeholder is always emitted first (`{value, plural, ...}`),
+        // but its numeric index must be allocated in source order relative to the
+        // cases. Render the cases into `tail` so they can follow the value in the
+        // output, while index allocation happens as each case is processed.
+        let mut value = Some(value);
+        let mut value_placeholder: Option<String> = None;
+        let mut tail = String::new();
+
+        for (i, choice) in cases.into_iter().enumerate() {
+            if i == value_pos {
+                value_placeholder = Some(self.push_exp(value.take().unwrap()));
+            }
+
             match choice {
                 // produce offset:{number}
                 CaseOrOffset::Offset(val) => {
-                    self.push_msg(&format!(" offset:{val}"));
+                    tail.push_str(&format!(" offset:{val}"));
                 }
                 CaseOrOffset::Case(choice) => {
                     let key = choice.key;
 
-                    self.push_msg(&format!(" {key} {{"));
+                    // Render the case body into `self.message`, then split it off
+                    // so it can be placed after the value. Index allocation
+                    // (numeric_index / values_indexed) persists across the split.
+                    let body_start = self.message.len();
                     self.process_tokens(choice.tokens);
-                    self.push_msg("}");
+                    let body = self.message.split_off(body_start);
+                    tail.push_str(&format!(" {key} {{{body}}}"));
                 }
             }
         }
 
-        self.push_msg("}");
+        // `value_pos` may equal `cases.len()` (value is the last/only attribute).
+        let value_placeholder = match value_placeholder {
+            Some(placeholder) => placeholder,
+            None => self.push_exp(value.take().unwrap()),
+        };
+
+        self.push_msg(&format!("{{{value_placeholder}, {method},{tail}}}"));
     }
 }

--- a/crates/lingui_macro/src/jsx_visitor.rs
+++ b/crates/lingui_macro/src/jsx_visitor.rs
@@ -112,14 +112,25 @@ fn is_allowed_plural_option(key: &str) -> Option<Atom> {
 
 impl TransJSXVisitor<'_> {
     // <Plural /> <Select /> <SelectOrdinal />
-    fn visit_icu_macro(&mut self, el: &JSXOpeningElement, icu_format: &str) -> Vec<CaseOrOffset> {
+    fn visit_icu_macro(
+        &mut self,
+        el: &JSXOpeningElement,
+        icu_format: &str,
+    ) -> (Vec<CaseOrOffset>, usize) {
         let mut choices: Vec<CaseOrOffset> = Vec::new();
+        // Default to the front so a missing `value` attribute keeps the prior
+        // behaviour of allocating the value placeholder before any cases.
+        let mut value_pos = 0;
 
         for attr in &el.attrs {
             if let JSXAttrOrSpread::JSXAttr(attr) = attr {
                 if let Some(attr_value) = &attr.value {
                     if let JSXAttrName::Ident(ident) = &attr.name {
-                        if &ident.sym == "offset" && icu_format != "select" {
+                        if &ident.sym == "value" {
+                            // Remember where the value sits relative to the
+                            // cases so its index is allocated in source order.
+                            value_pos = choices.len();
+                        } else if &ident.sym == "offset" && icu_format != "select" {
                             if let Some(value) = get_jsx_attr_value_as_string(attr_value) {
                                 choices.push(CaseOrOffset::Offset(value.to_string()))
                             } else {
@@ -178,7 +189,7 @@ impl TransJSXVisitor<'_> {
             }
         }
 
-        choices
+        (choices, value_pos)
     }
 }
 
@@ -204,12 +215,13 @@ impl Visit for TransJSXVisitor<'_> {
                     .get_ident_export_name(ident)
                     .unwrap()
                     .to_lowercase();
-                let choices = self.visit_icu_macro(el, &icu_method);
+                let (choices, value_pos) = self.visit_icu_macro(el, &icu_method);
 
                 self.tokens.push(MsgToken::IcuChoice(IcuChoice {
                     cases: choices,
                     format: icu_method.into(),
                     value,
+                    value_pos,
                 }));
 
                 return;

--- a/crates/lingui_macro/src/macro_utils.rs
+++ b/crates/lingui_macro/src/macro_utils.rs
@@ -210,6 +210,7 @@ impl MacroCtx {
                     format: format.into(),
                     value: icu_value,
                     cases,
+                    value_pos: 0,
                 })]);
             } else {
                 // todo passed not an ObjectLiteral,

--- a/crates/lingui_macro/src/tokens.rs
+++ b/crates/lingui_macro/src/tokens.rs
@@ -19,6 +19,12 @@ pub struct IcuChoice {
     /// plural | select | selectOrdinal
     pub format: Atom,
     pub cases: Vec<CaseOrOffset>,
+    /// Position of the `value` among `cases` in source order, i.e. how many
+    /// cases/offsets precede it. Numeric placeholder indices are allocated in
+    /// source order, so the value's index must be assigned at this point to
+    /// match the JS macro implementation. For the `plural(value, {...})` call
+    /// form the value is always first, so this is `0`.
+    pub value_pos: usize,
 }
 
 pub enum CaseOrOffset {

--- a/crates/lingui_macro/tests/jsx_icu.rs
+++ b/crates/lingui_macro/tests/jsx_icu.rs
@@ -265,3 +265,26 @@ import { Trans } from "@lingui/react/macro";
 </Trans>;
      "#
 );
+
+// Regression: numeric placeholder indices must be allocated in source-attribute
+// order. Here a non-identifier `value` appears AFTER an option that contains a
+// numeric-indexed expression, so the option's expression takes index 0 and the
+// value takes index 1 — matching the reference (JS) macro.
+to!(
+    jsx_icu_value_index_follows_source_order,
+    r##"
+       import { Plural } from "@lingui/react/macro";
+
+       const x = <Plural one={`${a.b} glass`} value={items.length} other="many" />
+     "##
+);
+
+// Counterpart with the conventional value-first ordering: value takes index 0.
+to!(
+    jsx_icu_value_first_keeps_index_zero,
+    r##"
+       import { Plural } from "@lingui/react/macro";
+
+       const x = <Plural value={items.length} one={`${a.b} glass`} other="many" />
+     "##
+);

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_value_first_keeps_index_zero.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_value_first_keeps_index_zero.snap
@@ -1,0 +1,18 @@
+---
+source: crates/lingui_macro/tests/jsx_icu.rs
+---
+import { Plural } from "@lingui/react/macro";
+
+const x = <Plural value={items.length} one={`${a.b} glass`} other="many" />
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as Trans_ } from "@lingui/react";
+const x = <Trans_ {.../*i18n*/ {
+    id: "1D4idA",
+    values: {
+        0: items.length,
+        1: a.b
+    },
+    message: "{0, plural, one {{1} glass} other {many}}"
+}}/>;

--- a/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_value_index_follows_source_order.snap
+++ b/crates/lingui_macro/tests/snapshots/jsx_icu__jsx_icu_value_index_follows_source_order.snap
@@ -1,0 +1,18 @@
+---
+source: crates/lingui_macro/tests/jsx_icu.rs
+---
+import { Plural } from "@lingui/react/macro";
+
+const x = <Plural one={`${a.b} glass`} value={items.length} other="many" />
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { Trans as Trans_ } from "@lingui/react";
+const x = <Trans_ {.../*i18n*/ {
+    id: "HUUtwt",
+    values: {
+        0: a.b,
+        1: items.length
+    },
+    message: "{1, plural, one {{0} glass} other {many}}"
+}}/>;


### PR DESCRIPTION
For `<Plural>` / `<Select>` / `<SelectOrdinal>`, the SWC plugin always allocated the `value` expression's index first, before processing the option attributes (`one`, `other`, …). While this is probably more intuitive, the JS implementation instead iterates attributes in **source order** and allocates the value's index at the position where the `value` attribute actually appears.

This only diverges when a non-identifier `value` is not the first attribute and an earlier option contains a numeric-indexed expression — but when it does, the numbers differ:

```tsx
<Plural one={`${a.b} glass`} value={items.length} other="many" />
```

| | message |
|---|---|
| Before | `{0, plural, one {{1} glass} other {many}}` |
| After / in JS | `{1, plural, one {{0} glass} other {many}}` |

> ❓ **Would it be worthwhile to update the JS implementation to match the SWC version instead?**

With the conventional value-first ordering both implementations already agreed (`value` → `{0}`), so existing snapshots were unaffected.

### Fix

- The token now records `value_pos`: the position of the `value` attribute among the cases in source order (`0` for the `plural(value, { … })` call form, where the value is always first).
- `push_icu` allocates the value's index at `value_pos` while iterating the cases, so indices are consumed in source order. The value placeholder is still emitted first in the ICU string by rendering each case body into a buffer (via `String::split_off`) and assembling `{value, format, …cases}` at the end.
  Index allocation (`numeric_index` / `values_indexed`) persists across the split, so only the *output position* is decoupled from the *allocation order*.
