### PR TITLE
fix: improve tsconfig to flag `.js` required extensions

### DIFF
--- a/packages/lingui-macro/tsconfig.build.json
+++ b/packages/lingui-macro/tsconfig.build.json
@@ -5,8 +5,8 @@
     "outDir": "./dist",
     "rootDir": "./src-js",
     "declaration": true,
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
   "include": [
     "src-js"

--- a/packages/lingui-macro/tsconfig.json
+++ b/packages/lingui-macro/tsconfig.json
@@ -1,21 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "noEmit": true,
-    "strict": true,
-    "outDir": "./dist",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "types": [
-      "vitest/globals",
-      "node"
-    ]
-  },
-  "include": [
-    "e2e",
-    "./vitest.config.ts"
-  ],
-  "exclude": [
-    "node_modules"
+  "references": [
+    {
+      "path": "tsconfig.build.json"
+    },
+    {
+      "path": "tsconfig.test.json"
+    }
   ]
 }

--- a/packages/lingui-macro/tsconfig.test.json
+++ b/packages/lingui-macro/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "noEmit": true,
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": [
+      "vitest/globals",
+      "node"
+    ]
+  },
+  "include": [
+    "e2e",
+    "./vitest.config.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
follow up for https://github.com/lingui/swc-plugin/pull/237 

Setup typescript so it would flag imports without explicit `.js` extension