### PR TITLE
fix: unwrap non-null assertion (`x!`) / `satisfies` in placeholders (parity with babel macro)

### DIFF
--- a/crates/lingui_macro/src/macro_utils.rs
+++ b/crates/lingui_macro/src/macro_utils.rs
@@ -9,7 +9,7 @@ use swc_core::ecma::{ast::*, atoms::Atom};
 use swc_core::plugin::errors::HANDLER;
 
 fn expression_to_name(expr: &Expr, ctx: &mut MacroCtx) -> String {
-    let expr = unwrap_ts_as_expr(expr);
+    let expr = unwrap_ts_only_expr(expr);
 
     match expr {
         Expr::Ident(ident) => ident.sym.to_string(),
@@ -33,7 +33,7 @@ fn expression_to_name(expr: &Expr, ctx: &mut MacroCtx) -> String {
 }
 
 fn expression_to_value(expr: Box<Expr>) -> Box<Expr> {
-    let unwrapped = unwrap_ts_as_expr(&expr);
+    let unwrapped = unwrap_ts_only_expr(&expr);
 
     match unwrapped {
         Expr::Object(object) => {
@@ -66,14 +66,18 @@ fn expression_to_value(expr: Box<Expr>) -> Box<Expr> {
     }
 }
 
-// recursively expands TypeScript's as expressions until it reaches a real value
-fn unwrap_ts_as_expr(expr: &Expr) -> &Expr {
+// recursively unwraps TypeScript-only expression wrappers (`x as T`, `x!`,
+// `x satisfies T`) until it reaches a real value, so the inner expression drives
+// placeholder naming (e.g. `${x!}` → `{x}`, not `{0}`).
+fn unwrap_ts_only_expr(expr: &Expr) -> &Expr {
     let mut current = expr;
-    while let Expr::TsAs(TsAsExpr {
-        expr: inner_expr, ..
-    }) = current
-    {
-        current = inner_expr;
+    loop {
+        current = match current {
+            Expr::TsAs(TsAsExpr { expr, .. })
+            | Expr::TsNonNull(TsNonNullExpr { expr, .. })
+            | Expr::TsSatisfies(TsSatisfiesExpr { expr, .. }) => expr,
+            _ => break,
+        };
     }
     current
 }

--- a/crates/lingui_macro/tests/js_t.rs
+++ b/crates/lingui_macro/tests/js_t.rs
@@ -238,3 +238,11 @@ to!(
      t`Variable ${name!}`;
      "#
 );
+
+to!(
+    js_satisfies_gets_named_placeholder,
+    r#"
+     import { t } from '@lingui/core/macro';
+     t`Variable ${name satisfies string}`;
+     "#
+);

--- a/crates/lingui_macro/tests/js_t.rs
+++ b/crates/lingui_macro/tests/js_t.rs
@@ -228,3 +228,13 @@ to!(
      t`Hello World`
      "#
 );
+
+// TS-only expression wrappers unwrap to a named placeholder (parity with `as`),
+// matching @lingui/babel-plugin-lingui-macro (see lingui/js-lingui#2622).
+to!(
+    js_non_null_assertion_gets_named_placeholder,
+    r#"
+     import { t } from '@lingui/core/macro';
+     t`Variable ${name!}`;
+     "#
+);

--- a/crates/lingui_macro/tests/snapshots/js_t__js_non_null_assertion_gets_named_placeholder.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_non_null_assertion_gets_named_placeholder.snap
@@ -1,0 +1,16 @@
+---
+source: crates/lingui_macro/tests/js_t.rs
+---
+import { t } from '@lingui/core/macro';
+t`Variable ${name!}`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as $_i18n } from "@lingui/core";
+$_i18n._(/*i18n*/ {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+        name: name!
+    }
+});

--- a/crates/lingui_macro/tests/snapshots/js_t__js_satisfies_gets_named_placeholder.snap
+++ b/crates/lingui_macro/tests/snapshots/js_t__js_satisfies_gets_named_placeholder.snap
@@ -1,0 +1,16 @@
+---
+source: crates/lingui_macro/tests/js_t.rs
+---
+import { t } from '@lingui/core/macro';
+t`Variable ${name satisfies string}`;
+
+↓ ↓ ↓ ↓ ↓ ↓
+
+import { i18n as $_i18n } from "@lingui/core";
+$_i18n._(/*i18n*/ {
+    id: "xRRkAE",
+    message: "Variable {name}",
+    values: {
+        name: name satisfies string
+    }
+});


### PR DESCRIPTION
## Description

Companion to lingui/js-lingui#2622.

`unwrap_ts_only_expr` (renamed from `unwrap_ts_as_expr`) only unwrapped `TsAs`, so a placeholder whose expression is wrapped in a **non-null assertion** (`x!`) or `satisfies` fell through to the numeric-index branch and got an **indexed** placeholder (`{0}`) instead of a **named** one (`{x}`), diverging from `@lingui/babel-plugin-lingui-macro`. Same class as #239.

This unwraps `TsNonNull` and `TsSatisfies` alongside `TsAs` so all TS-only wrappers let the inner expression name the placeholder.

## ⚠️ Important: real-world impact is limited (please read)

In practice `@swc/core` strips TS-only operators **before** this plugin runs, so consumers going through `@swc/core` (rspack, Next.js, Vite, rsbuild, …) **already get the named placeholder today** — the plugin never sees the `!`. Verified locally with `@swc/core@1.15.43` + `@lingui/swc-plugin@6.5.1`:

```
// @swc/core alone
const y = x!;   ->   const y = x;

// @swc/core + @lingui/swc-plugin
t`no.: ${x!}`   ->   _i18n._({ id: "FPCAwc", message: "no.: {x}", values: { x: x } })   // named
```

So the `{0}` only surfaces when the plugin transforms a **not-yet-stripped** TS AST — e.g. this crate's own `to!` test harness (which feeds the parsed AST directly to the visitor). Before this change, the added test snapshots `Variable {0}`; after it, `Variable {name}`.

**Why fix it anyway:** it makes the plugin's placeholder naming correct independent of pipeline ordering, keeps it consistent with the babel macro (js-lingui#2622), and is what lets the regression test assert `{name}` (parity) rather than a misleading `{0}`. It does not change output for the common `@swc/core` pipelines.

## Test

Adds `js_non_null_assertion_gets_named_placeholder` in `js_t.rs` (mirrors the js-lingui regression test). Full `lingui_macro` suite passes with no other snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)